### PR TITLE
Expand schema $refs into nested field tables at --detail full (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Schema expansion at `--detail full --include-schemas` (#5): the `Schema` model
+  now captures `title`, `description`, `format`, `properties`, `items`,
+  `required`, `allOf`/`oneOf`/`anyOf`, `enum`, `nullable`, and
+  `additionalProperties`, and request/response schemas are rendered as nested
+  field tables instead of a one-line type or reference name. `$ref`s are
+  resolved against `components.schemas` (OpenAPI 3) and `definitions`
+  (OpenAPI 2), with cycle detection and a depth guard so self-referential
+  schemas terminate cleanly
+
 ## [0.2.2] - 2026-06-11
 
 ### Added
@@ -65,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release: OpenAPI 2.0 (Swagger) JSON to Markdown with grouping,
   filtering, sorting, and detail levels
 
+[Unreleased]: https://github.com/nrynss/vimanam/compare/v0.2.2...HEAD
 [0.2.2]: https://github.com/nrynss/vimanam/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/nrynss/vimanam/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/nrynss/vimanam/compare/v0.1.1...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.3] - 2026-06-15
 
 ### Added
 
@@ -78,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release: OpenAPI 2.0 (Swagger) JSON to Markdown with grouping,
   filtering, sorting, and detail levels
 
-[Unreleased]: https://github.com/nrynss/vimanam/compare/v0.2.2...HEAD
+[0.2.3]: https://github.com/nrynss/vimanam/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/nrynss/vimanam/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/nrynss/vimanam/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/nrynss/vimanam/compare/v0.1.1...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.3] - 2026-06-15
+## [0.3.0] - 2026-06-15
 
 ### Added
 
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolved against `components.schemas` (OpenAPI 3) and `definitions`
   (OpenAPI 2), with cycle detection and a depth guard so self-referential
   schemas terminate cleanly
+
+### Changed
+
+- `--detail full --include-schemas` output format: request/response schemas now
+  render as `| Field | Type | Required | Description |` tables instead of the
+  previous single-line `// Schema type:` / `// Reference:` comment
 
 ## [0.2.2] - 2026-06-11
 
@@ -78,7 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release: OpenAPI 2.0 (Swagger) JSON to Markdown with grouping,
   filtering, sorting, and detail levels
 
-[0.2.3]: https://github.com/nrynss/vimanam/compare/v0.2.2...v0.2.3
+[0.3.0]: https://github.com/nrynss/vimanam/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/nrynss/vimanam/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/nrynss/vimanam/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/nrynss/vimanam/compare/v0.1.1...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vimanam"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vimanam"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vimanam"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Narayan SS <nrynss@users.noreply.github.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vimanam"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Narayan SS <nrynss@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Besides producing documentation for humans, Vimanam is built for **feeding API s
 - Group endpoints by service or HTTP method, or list them flat
 - Filter by service, path, or method
 - Multiple detail levels (summary, basic, standard, full)
-- Reference resolution to follow JSON references (`$ref`) in specifications
+- Schema expansion at `--detail full --include-schemas`: resolves `$ref`s (with cycle detection) and renders request/response schemas as nested field tables
 - Server URL information extraction and documentation
 - Authentication and security schemes documentation
 - Proper content type detection for responses

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -3,7 +3,9 @@ use std::io::Write;
 
 use anyhow::Result;
 
-use crate::models::{ApiDocumentation, DetailLevel, DocConfig, Endpoint, GroupBy};
+use crate::models::{
+    ApiDocumentation, DetailLevel, DocConfig, Endpoint, GroupBy, Response, Schema,
+};
 use crate::utils::{clean_for_id, extract_content_type};
 
 /// Renders the documentation to `writer`, dispatching on detail level and grouping mode.
@@ -276,7 +278,7 @@ fn generate_by_service<W: Write>(
             }
 
             for endpoint in sorted_endpoints {
-                write_endpoint(writer, endpoint, config, true)?;
+                write_endpoint(writer, endpoint, doc, config, true)?;
             }
         } else {
             writeln!(writer, "\nNo endpoints found for this service.\n")?;
@@ -390,7 +392,7 @@ fn generate_by_method<W: Write>(
                 }
 
                 for endpoint in sorted_endpoints {
-                    write_endpoint(writer, endpoint, config, true)?;
+                    write_endpoint(writer, endpoint, doc, config, true)?;
                 }
             }
         }
@@ -469,7 +471,7 @@ fn generate_flat<W: Write>(
 
     writeln!(writer, "## Endpoints\n")?;
     for endpoint in endpoints {
-        write_endpoint(writer, endpoint, config, true)?;
+        write_endpoint(writer, endpoint, doc, config, true)?;
     }
 
     Ok(())
@@ -479,6 +481,7 @@ fn generate_flat<W: Write>(
 fn write_endpoint<W: Write>(
     writer: &mut W,
     endpoint: &Endpoint,
+    doc: &ApiDocumentation,
     config: &DocConfig,
     include_heading: bool,
 ) -> Result<()> {
@@ -574,11 +577,9 @@ fn write_endpoint<W: Write>(
 
             if let Some(param) = body_param {
                 if let Some(schema) = &param.schema {
-                    if let Some(schema_type) = &schema.schema_type {
-                        writeln!(writer, "```json\n// Schema type: {}\n```", schema_type)?;
-                    } else if let Some(ref_val) = &schema.reference {
-                        writeln!(writer, "```json\n// Reference: {}\n```", ref_val)?;
-                    }
+                    write_schema_table(writer, schema, doc, "request")?;
+                } else {
+                    writeln!(writer, "*No request schema available*")?;
                 }
             } else {
                 writeln!(writer, "*No request schema available*")?;
@@ -590,18 +591,8 @@ fn write_endpoint<W: Write>(
                 .iter()
                 .find(|(code, _)| code.starts_with('2'))
             {
-                if let Some(schema) = &response.schema {
-                    if let Some(schema_type) = &schema.schema_type {
-                        writeln!(writer, "```json\n// Schema type: {}\n```", schema_type)?;
-                    } else if let Some(ref_val) = &schema.reference {
-                        writeln!(writer, "```json\n// Reference: {}\n```", ref_val)?;
-                    }
-                } else if let Some(content) = &response.content {
-                    if let Some((content_type, media_type)) = content.iter().next() {
-                        if media_type.schema.is_some() {
-                            writeln!(writer, "```json\n// Content type: {}\n```", content_type)?;
-                        }
-                    }
+                if let Some(schema) = response_schema(response) {
+                    write_schema_table(writer, schema, doc, "response")?;
                 } else {
                     writeln!(writer, "*No response schema available*")?;
                 }
@@ -641,4 +632,288 @@ fn get_short_title(endpoint: &Endpoint) -> String {
 
     // Fallback to method and path
     format!("{} {}", endpoint.method, endpoint.path)
+}
+
+#[derive(Debug)]
+struct SchemaRow {
+    field: String,
+    type_name: String,
+    required: String,
+    description: String,
+}
+
+fn response_schema(response: &Response) -> Option<&Schema> {
+    if let Some(schema) = &response.schema {
+        return Some(schema);
+    }
+
+    response
+        .content
+        .as_ref()
+        .and_then(|content| content.values().find_map(|media| media.schema.as_ref()))
+}
+
+fn write_schema_table<W: Write>(
+    writer: &mut W,
+    schema: &Schema,
+    doc: &ApiDocumentation,
+    root_label: &str,
+) -> Result<()> {
+    let mut rows = Vec::new();
+    let mut ref_stack = Vec::new();
+    collect_schema_rows(schema, doc, root_label, None, &mut rows, &mut ref_stack, 0);
+
+    if rows.is_empty() {
+        writeln!(writer, "*No schema fields available*")?;
+        return Ok(());
+    }
+
+    writeln!(writer, "| Field | Type | Required | Description |")?;
+    writeln!(writer, "|------|------|---------:|-------------|")?;
+    for row in rows {
+        writeln!(
+            writer,
+            "| `{}` | {} | {} | {} |",
+            row.field,
+            escape_table_cell(&row.type_name),
+            row.required,
+            escape_table_cell(&row.description)
+        )?;
+    }
+
+    Ok(())
+}
+
+fn collect_schema_rows(
+    schema: &Schema,
+    doc: &ApiDocumentation,
+    field: &str,
+    required: Option<bool>,
+    rows: &mut Vec<SchemaRow>,
+    ref_stack: &mut Vec<String>,
+    depth: usize,
+) {
+    const MAX_DEPTH: usize = 24;
+
+    if depth >= MAX_DEPTH {
+        rows.push(SchemaRow {
+            field: field.to_string(),
+            type_name: "truncated".to_string(),
+            required: required_to_string(required).to_string(),
+            description: "Maximum schema depth reached; nested expansion stopped".to_string(),
+        });
+        return;
+    }
+
+    if let Some(reference) = &schema.reference {
+        if ref_stack.contains(reference) {
+            rows.push(SchemaRow {
+                field: field.to_string(),
+                type_name: format!("ref {}", short_schema_reference(reference)),
+                required: required_to_string(required).to_string(),
+                description: "Cycle detected while expanding schema reference".to_string(),
+            });
+            return;
+        }
+
+        if let Some(resolved) = resolve_schema_reference(reference, doc) {
+            ref_stack.push(reference.clone());
+            collect_schema_rows(resolved, doc, field, required, rows, ref_stack, depth + 1);
+            ref_stack.pop();
+            return;
+        }
+
+        rows.push(SchemaRow {
+            field: field.to_string(),
+            type_name: format!("ref {}", short_schema_reference(reference)),
+            required: required_to_string(required).to_string(),
+            description: format!("Unresolved schema reference: {}", reference),
+        });
+        return;
+    }
+
+    let description = schema.description.as_deref().unwrap_or("-");
+    rows.push(SchemaRow {
+        field: field.to_string(),
+        type_name: schema_type_label(schema),
+        required: required_to_string(required).to_string(),
+        description: description.to_string(),
+    });
+
+    if let Some(properties) = &schema.properties {
+        let required_fields: HashSet<&str> = schema
+            .required
+            .as_ref()
+            .map(|items| items.iter().map(String::as_str).collect())
+            .unwrap_or_default();
+
+        for (name, child_schema) in properties {
+            let child_field = format_field(field, name);
+            collect_schema_rows(
+                child_schema,
+                doc,
+                &child_field,
+                Some(required_fields.contains(name.as_str())),
+                rows,
+                ref_stack,
+                depth + 1,
+            );
+        }
+    }
+
+    if let Some(items) = &schema.items {
+        let item_field = format!("{}[]", field);
+        collect_schema_rows(items, doc, &item_field, None, rows, ref_stack, depth + 1);
+    }
+
+    if let Some(all_of) = &schema.all_of {
+        for (index, variant) in all_of.iter().enumerate() {
+            let variant_field = format!("{}.allOf[{}]", field, index + 1);
+            collect_schema_rows(
+                variant,
+                doc,
+                &variant_field,
+                required,
+                rows,
+                ref_stack,
+                depth + 1,
+            );
+        }
+    }
+
+    if let Some(one_of) = &schema.one_of {
+        for (index, variant) in one_of.iter().enumerate() {
+            let variant_field = format!("{}.oneOf[{}]", field, index + 1);
+            collect_schema_rows(
+                variant,
+                doc,
+                &variant_field,
+                required,
+                rows,
+                ref_stack,
+                depth + 1,
+            );
+        }
+    }
+
+    if let Some(any_of) = &schema.any_of {
+        for (index, variant) in any_of.iter().enumerate() {
+            let variant_field = format!("{}.anyOf[{}]", field, index + 1);
+            collect_schema_rows(
+                variant,
+                doc,
+                &variant_field,
+                required,
+                rows,
+                ref_stack,
+                depth + 1,
+            );
+        }
+    }
+}
+
+fn resolve_schema_reference<'a>(reference: &str, doc: &'a ApiDocumentation) -> Option<&'a Schema> {
+    if let Some(name) = reference.strip_prefix("#/components/schemas/") {
+        return doc.schemas.get(&decode_json_pointer_token(name));
+    }
+
+    if let Some(name) = reference.strip_prefix("#/definitions/") {
+        return doc.schemas.get(&decode_json_pointer_token(name));
+    }
+
+    None
+}
+
+fn schema_type_label(schema: &Schema) -> String {
+    let mut label = if let Some(schema_type) = &schema.schema_type {
+        if schema_type == "array" {
+            let item_label = schema
+                .items
+                .as_deref()
+                .map(schema_type_hint)
+                .unwrap_or_else(|| "unknown".to_string());
+            format!("array<{}>", item_label)
+        } else if let Some(format) = &schema.format {
+            format!("{}({})", schema_type, format)
+        } else {
+            schema_type.clone()
+        }
+    } else if schema.properties.is_some() {
+        "object".to_string()
+    } else if schema.items.is_some() {
+        let item_label = schema
+            .items
+            .as_deref()
+            .map(schema_type_hint)
+            .unwrap_or_else(|| "unknown".to_string());
+        format!("array<{}>", item_label)
+    } else if schema.all_of.as_ref().is_some_and(|v| !v.is_empty()) {
+        "allOf".to_string()
+    } else if schema.one_of.as_ref().is_some_and(|v| !v.is_empty()) {
+        "oneOf".to_string()
+    } else if schema.any_of.as_ref().is_some_and(|v| !v.is_empty()) {
+        "anyOf".to_string()
+    } else if let Some(enum_values) = &schema.enum_values {
+        format!("enum[{}]", enum_values.len())
+    } else {
+        "unknown".to_string()
+    };
+
+    if schema.nullable.unwrap_or(false) {
+        label.push_str(" | null");
+    }
+
+    label
+}
+
+fn schema_type_hint(schema: &Schema) -> String {
+    if let Some(reference) = &schema.reference {
+        return format!("ref {}", short_schema_reference(reference));
+    }
+
+    if let Some(schema_type) = &schema.schema_type {
+        return schema_type.clone();
+    }
+
+    if schema.properties.is_some() {
+        return "object".to_string();
+    }
+
+    if schema.items.is_some() {
+        return "array".to_string();
+    }
+
+    "unknown".to_string()
+}
+
+fn format_field(parent: &str, child: &str) -> String {
+    if parent.is_empty() {
+        return child.to_string();
+    }
+
+    format!("{}.{}", parent, child)
+}
+
+fn required_to_string(required: Option<bool>) -> &'static str {
+    match required {
+        Some(true) => "Yes",
+        Some(false) => "No",
+        None => "-",
+    }
+}
+
+fn short_schema_reference(reference: &str) -> String {
+    reference
+        .rsplit('/')
+        .next()
+        .map(decode_json_pointer_token)
+        .unwrap_or_else(|| reference.to_string())
+}
+
+fn decode_json_pointer_token(token: &str) -> String {
+    token.replace("~1", "/").replace("~0", "~")
+}
+
+fn escape_table_cell(value: &str) -> String {
+    value.replace('|', "\\|").replace('\n', "<br/>")
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -177,6 +177,8 @@ pub struct Components {
     pub security_schemes: Option<HashMap<String, SecurityScheme>>,
     pub links: Option<HashMap<String, Link>>,
     pub callbacks: Option<HashMap<String, Callback>>,
+    #[serde(flatten)]
+    pub extensions: HashMap<String, serde_json::Value>,
 }
 
 // Example struct

--- a/src/models.rs
+++ b/src/models.rs
@@ -30,6 +30,12 @@ pub struct OpenApiSpec {
     #[serde(flatten)]
     pub extensions: HashMap<String, serde_json::Value>,
 }
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(untagged)]
+pub enum AdditionalProperties {
+    Bool(bool),
+    Schema(Box<Schema>),
+}
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Info {
@@ -96,10 +102,37 @@ pub struct Parameter {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Schema {
+    #[serde(rename = "title", skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(rename = "description", skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub schema_type: Option<String>,
+    #[serde(rename = "format", skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
     #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
     pub reference: Option<String>,
+    #[serde(rename = "properties", skip_serializing_if = "Option::is_none")]
+    pub properties: Option<IndexMap<String, Schema>>,
+    #[serde(rename = "items", skip_serializing_if = "Option::is_none")]
+    pub items: Option<Box<Schema>>,
+    #[serde(rename = "required", skip_serializing_if = "Option::is_none")]
+    pub required: Option<Vec<String>>,
+    #[serde(rename = "allOf", skip_serializing_if = "Option::is_none")]
+    pub all_of: Option<Vec<Schema>>,
+    #[serde(rename = "oneOf", skip_serializing_if = "Option::is_none")]
+    pub one_of: Option<Vec<Schema>>,
+    #[serde(rename = "anyOf", skip_serializing_if = "Option::is_none")]
+    pub any_of: Option<Vec<Schema>>,
+    #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<Vec<serde_json::Value>>,
+    #[serde(rename = "nullable", skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+    #[serde(
+        rename = "additionalProperties",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_properties: Option<AdditionalProperties>,
     #[serde(flatten)]
     pub extensions: HashMap<String, serde_json::Value>,
 }
@@ -133,7 +166,7 @@ pub struct ServerVariable {
 // Components definition for OpenAPI 3.0+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Components {
-    pub schemas: Option<HashMap<String, Schema>>,
+    pub schemas: Option<IndexMap<String, Schema>>,
     pub responses: Option<HashMap<String, Response>>,
     pub parameters: Option<HashMap<String, Parameter>>,
     pub examples: Option<HashMap<String, Example>>,
@@ -322,4 +355,5 @@ pub struct ApiDocumentation {
     pub endpoints: Vec<Endpoint>,
     pub servers: Vec<String>,
     pub security_schemes: HashMap<String, String>,
+    pub schemas: IndexMap<String, Schema>,
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,9 @@ use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
-use crate::models::{ApiDocumentation, Endpoint, OpenApiSpec, Parameter, Response, Service};
+use crate::models::{
+    ApiDocumentation, Endpoint, OpenApiSpec, Parameter, Response, Schema, Service,
+};
 use crate::utils::{
     extract_security_schemes, extract_servers, resolve_parameter_ref, resolve_response_ref,
 };
@@ -39,6 +41,8 @@ pub fn parse_openapi<P: AsRef<Path>>(path: P) -> Result<ApiDocumentation> {
 
             let endpoints = extract_endpoints(&spec, &services);
             debug!("Extracted {} endpoints", endpoints.len());
+            let schemas = extract_schemas(&spec);
+            debug!("Extracted {} reusable schemas", schemas.len());
 
             Ok(ApiDocumentation {
                 title: spec.info.title,
@@ -48,6 +52,7 @@ pub fn parse_openapi<P: AsRef<Path>>(path: P) -> Result<ApiDocumentation> {
                 endpoints,
                 servers,
                 security_schemes,
+                schemas,
             })
         }
         Err(err) => {
@@ -304,4 +309,36 @@ fn extract_endpoints(spec: &OpenApiSpec, services: &[Service]) -> Vec<Endpoint> 
     }
 
     endpoints
+}
+
+/// Collects reusable schemas from OpenAPI 3 `components.schemas` and
+/// OpenAPI 2 `definitions` into a deterministic registry.
+fn extract_schemas(spec: &OpenApiSpec) -> IndexMap<String, Schema> {
+    let mut schemas = IndexMap::new();
+
+    if let Some(components) = &spec.components {
+        if let Some(component_schemas) = &components.schemas {
+            for (name, schema) in component_schemas {
+                schemas.insert(name.clone(), schema.clone());
+            }
+        }
+    }
+
+    if let Some(definitions) = spec
+        .extensions
+        .get("definitions")
+        .and_then(|v| v.as_object())
+    {
+        for (name, raw_schema) in definitions {
+            if schemas.contains_key(name) {
+                continue;
+            }
+
+            if let Ok(schema) = serde_json::from_value::<Schema>(raw_schema.clone()) {
+                schemas.insert(name.clone(), schema);
+            }
+        }
+    }
+
+    schemas
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -334,8 +334,16 @@ fn extract_schemas(spec: &OpenApiSpec) -> IndexMap<String, Schema> {
                 continue;
             }
 
-            if let Ok(schema) = serde_json::from_value::<Schema>(raw_schema.clone()) {
-                schemas.insert(name.clone(), schema);
+            match serde_json::from_value::<Schema>(raw_schema.clone()) {
+                Ok(schema) => {
+                    schemas.insert(name.clone(), schema);
+                }
+                Err(err) => {
+                    warn!(
+                        "Skipping definition '{}': failed to parse schema: {}",
+                        name, err
+                    );
+                }
             }
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 
 const OAS3: &str = "tests/fixtures/petstore_oas3.json";
 const OAS2: &str = "tests/fixtures/petstore_oas2.json";
+const OAS3_SCHEMA_REFS: &str = "tests/fixtures/schema_refs_oas3.json";
 
 fn vimanam() -> Command {
     Command::cargo_bin("vimanam").unwrap()
@@ -207,4 +208,36 @@ fn output_is_deterministic() {
     for _ in 0..4 {
         assert_eq!(first, run(), "output differed between identical runs");
     }
+}
+
+#[test]
+fn full_detail_expands_schema_refs_into_tables() {
+    vimanam()
+        .arg(OAS3_SCHEMA_REFS)
+        .args(["--detail", "full", "--include-schemas"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#### Request Schema"))
+        .stdout(predicate::str::contains(
+            "| `request.name` | string | Yes | Pet name |",
+        ))
+        .stdout(predicate::str::contains(
+            "| `request.category.id` | string | Yes | Category identifier |",
+        ))
+        .stdout(predicate::str::contains(
+            "| `response.allOf[2].id` | string | Yes | Pet identifier |",
+        ))
+        .stdout(predicate::str::contains("request.variant.oneOf[1]"));
+}
+
+#[test]
+fn full_detail_schema_expansion_detects_ref_cycles() {
+    vimanam()
+        .arg(OAS3_SCHEMA_REFS)
+        .args(["--detail", "full", "--include-schemas"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Cycle detected while expanding schema reference",
+        ));
 }

--- a/tests/fixtures/schema_refs_oas3.json
+++ b/tests/fixtures/schema_refs_oas3.json
@@ -1,0 +1,113 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Schema Ref API",
+    "version": "1.0.0"
+  },
+  "tags": [
+    { "name": "Pets", "description": "Pet operations" },
+    { "name": "Nodes", "description": "Node operations" }
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "tags": ["Pets"],
+        "summary": "Create pet",
+        "operationId": "Pets_CreatePet",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreatePetRequest" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nodes/{nodeId}": {
+      "get": {
+        "tags": ["Nodes"],
+        "summary": "Get node",
+        "operationId": "Nodes_GetNode",
+        "parameters": [
+          {
+            "name": "nodeId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Node payload",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Node" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreatePetRequest": {
+        "type": "object",
+        "required": ["name", "category"],
+        "properties": {
+          "name": { "type": "string", "description": "Pet name" },
+          "age": { "type": "integer", "format": "int32" },
+          "category": { "$ref": "#/components/schemas/Category" },
+          "variant": {
+            "oneOf": [
+              { "type": "string", "description": "Variant as string" },
+              { "type": "integer", "description": "Variant as integer" }
+            ]
+          }
+        }
+      },
+      "Category": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string", "description": "Category identifier" },
+          "label": { "type": "string" }
+        }
+      },
+      "Pet": {
+        "allOf": [
+          { "$ref": "#/components/schemas/CreatePetRequest" },
+          {
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+              "id": { "type": "string", "description": "Pet identifier" },
+              "friends": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/Pet" }
+              }
+            }
+          }
+        ]
+      },
+      "Node": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "next": { "$ref": "#/components/schemas/Node" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #5.

Before this change, `--detail full --include-schemas` could only emit a single line — the schema type or the raw reference name (e.g. `// Reference: #/components/schemas/Pet`). This delivers on `--include-schemas` by modeling the schema shape and expanding `$ref`s into readable, nested field tables.

## Changes

- **models** — `Schema` now captures `title`, `description`, `format`, `properties`, `items`, `required`, `allOf`/`oneOf`/`anyOf`, `enum`, `nullable`, and `additionalProperties`. `components.schemas` and the new `ApiDocumentation.schemas` registry use `IndexMap` to preserve the project's deterministic-output invariant.
- **parser** — `extract_schemas` collects reusable schemas from OpenAPI 3 `components.schemas` and OpenAPI 2 `definitions` into the registry.
- **markdown** — request/response schemas render as nested field tables. `$ref`s resolve against the registry with cycle detection and a depth guard, so self-referential schemas (e.g. `Node.next → Node`) terminate cleanly.
- **tests** — new `schema_refs_oas3` fixture plus coverage for ref expansion, `allOf`/`oneOf`, and cycle detection.
- **docs** — README feature line updated; CHANGELOG `0.3.0` entry added; version bumped to `0.3.0`.

## Example output

```
#### Request Schema
| Field | Type | Required | Description |
|------|------|---------:|-------------|
| `request` | object | - | - |
| `request.name` | string | Yes | Pet name |
| `request.category` | object | Yes | - |
| `request.category.id` | string | Yes | Category identifier |
| `request.variant` | oneOf | No | - |
| `request.variant.oneOf[1]` | string | No | Variant as string |
```

## Testing

- `cargo test` — 17 passed (2 new)
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced schema rendering with `--detail full --include-schemas` flags to expand schema references (`$ref`) into nested field tables.
  * Added support for resolving OpenAPI 3 `components.schemas` and OpenAPI 2 `definitions` with cycle detection and depth guarding.
  * Improved schema field coverage including title, description, format, enum values, and composite keywords.

* **Documentation**
  * Updated CHANGELOG and README to reflect new schema expansion capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->