### PR TITLE
ci(release): fail release if tag doesn't match Cargo.toml version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,28 @@ permissions:
   contents: write
 
 jobs:
+  verify-version:
+    name: Verify tag matches crate version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Check tag matches Cargo.toml version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CARGO_VERSION="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/^version = "(.*)"/\1/')"
+          echo "Tag version:   $TAG_VERSION"
+          echo "Cargo version: $CARGO_VERSION"
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION does not match Cargo.toml version $CARGO_VERSION. Bump Cargo.toml (and Cargo.lock) to match the tag before releasing."
+            exit 1
+          fi
+
   create-release:
     name: Create Release
+    needs: verify-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -40,6 +60,7 @@ jobs:
 
   publish-crate:
     name: Publish to crates.io
+    needs: verify-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary

The release workflow triggers on a `v*` tag push but never checks that the tag matches the crate version in `Cargo.toml`. Since `cargo publish` uses `Cargo.toml`'s version (not the tag), a drift could publish a GitHub release titled e.g. `v0.3.0` while crates.io silently receives `0.2.3`.

This adds a `verify-version` job that fails fast on mismatch, and makes `create-release` and `publish-crate` depend on it (`build-and-upload` already depends on `create-release`, so it's covered transitively).

## Behavior

- Tag `v0.3.0` + `Cargo.toml` `0.3.0` → passes, release proceeds.
- Tag `v0.3.0` + `Cargo.toml` `0.2.3` → job fails with an actionable error before anything is published.

## Notes

- No toolchain needed; the version is read with `grep`/`sed`.
- Pure CI change — independent of the schema-`$ref` feature in #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)