### PR TITLE
fix: make fatal errors visible regardless of RUST_LOG setting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use std::process;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use log::{error, info};
+use log::info;
 
 use crate::config::{build_config, Cli};
 use crate::markdown::generate_markdown;
@@ -56,7 +56,7 @@ fn run() -> Result<()> {
 
 fn main() {
     if let Err(err) = run() {
-        error!("Error: {:#}", err);
+        eprintln!("Error: {:#}", err);
         process::exit(1);
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -173,7 +173,11 @@ fn invalid_json_fails() {
     let mut file = tempfile::NamedTempFile::new().unwrap();
     write!(file, "this is not json").unwrap();
 
-    vimanam().arg(file.path()).assert().failure();
+    vimanam()
+        .arg(file.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error:"));
 }
 
 #[test]
@@ -181,7 +185,11 @@ fn json_without_openapi_fields_fails() {
     let mut file = tempfile::NamedTempFile::new().unwrap();
     write!(file, "{{\"hello\": \"world\"}}").unwrap();
 
-    vimanam().arg(file.path()).assert().failure();
+    vimanam()
+        .arg(file.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error:"));
 }
 
 // Output must be byte-identical across runs, even with sorting disabled.


### PR DESCRIPTION
Fatal errors were being logged using the `error!()` macro from `env_logger`, which defaults to filter level `off`. This meant error messages were silently swallowed unless users explicitly set `RUST_LOG=error`. Users only saw non-zero exit codes with no output.

## Alternative Approaches Considered

**Option 1: Configure env_logger default filter**
```rust
env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("error")).init();
```
- Affects ALL logging behavior globally
- Still depends on user configuration for different log levels
- Overkill for just fatal errors

**Option 2: Use log::error!() with explicit level**
```rust
log::error!("Error: {:#}", err);
```
- Still subject to logging configuration
- Same visibility problem as original

**Option 3: Use eprintln!() (CHOSEN)**
```rust
eprintln!("Error: {:#}", err);
```
- Guaranteed visibility via stderr, bypassing logging configuration
- Minimal change: only 2 lines modified
- Follows Unix conventions: fatal errors → stderr, normal output → stdout
- No impact on non-fatal error logging behavior

## Solution
Changed the error logging in `src/main.rs:59` from:
```rust
error!("Error: {:#}", err);
```
to:
```rust
eprintln!("Error: {:#}", err);
```

Also removed the unused `error` import from line 13.

## Changes Made
- src/main.rs:59 - Replace `error!()` with `eprintln!()` for fatal errors
- src/main.rs:13 - Remove unused `error` import

## Testing
- ✅ Project builds successfully with no warnings
- ✅ All 17 tests pass  
- ✅ Verified error visibility with invalid JSON test case

## Technical Details
- Used `eprintln!()` which writes directly to stderr, bypassing logging configuration
- Minimal change: only 2 lines modified
- Follows Unix conventions: fatal errors → stderr, normal output → stdout
- No impact on non-fatal error logging behavior

Fixes #14

**Sarvam 105B was the one who fixed it**"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting in the CLI to display error messages more clearly to stderr

<!-- end of auto-generated comment: release notes by coderabbit.ai -->