### PR TITLE
fix: resolve open bug/quality issues and release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-06-16
+
+### Fixed
+
+- Fatal errors are now printed to stderr regardless of the `RUST_LOG` setting,
+  instead of being silently swallowed when logging was not enabled (#14)
+- `--method-filter` is now case-insensitive; methods are stored uppercase, so a
+  lowercase value such as `--method-filter get` previously matched nothing and
+  silently produced empty output (#13)
+- `--service-filter` is now case-insensitive, for the same reason (#19)
+- `clean_for_id` now collapses runs of 3+ consecutive separators into a single
+  dash, so anchor IDs derived from inputs like `a///b` are clean (#15)
+- The `## Authentication` section is now emitted in spec order and is
+  deterministic across runs; `security_schemes` switched from `HashMap` to
+  `IndexMap` (#16)
+- The table of contents and body sections now share one endpoint ordering in
+  every view, so TOC anchor links always point to the corresponding section in
+  document order (#18)
+
+### Changed
+
+- Schema composition variant indices (`allOf`/`oneOf`/`anyOf`) are now 0-based
+  (`allOf[0]`, `allOf[1]`, ...) to match JSON Pointer/jq conventions (#21)
+
+### Performance
+
+- `$ref` resolution no longer re-serializes the entire spec on every reference;
+  the spec is serialized to JSON once per parse, making `$ref`-heavy large specs
+  significantly faster (#17)
+
+### Internal
+
+- `--group-by` is no longer wrapped in a misleading `Option` (it always has a
+  clap default), removing an unreachable fallback branch (#20)
+
 ## [0.3.0] - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dash, so anchor IDs derived from inputs like `a///b` are clean (#15)
 - The `## Authentication` section is now emitted in spec order and is
   deterministic across runs; `security_schemes` switched from `HashMap` to
-  `IndexMap` (#16)
+  `IndexMap`, and `serde_json`'s `preserve_order` feature keeps OpenAPI 2.0
+  `securityDefinitions` in declaration order rather than alphabetical (#16)
 - The table of contents and body sections now share one endpoint ordering in
   every view, so TOC anchor links always point to the corresponding section in
   document order (#18)
@@ -119,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release: OpenAPI 2.0 (Swagger) JSON to Markdown with grouping,
   filtering, sorting, and detail levels
 
+[0.4.0]: https://github.com/nrynss/vimanam/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/nrynss/vimanam/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/nrynss/vimanam/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/nrynss/vimanam/compare/v0.2.0...v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vimanam"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vimanam"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Narayan SS <nrynss@users.noreply.github.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,10 @@ clap = { version = "4.6", features = ["derive"] }
 
 # JSON parsing
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+# preserve_order keeps serde_json::Value object keys in spec order, so the
+# OpenAPI 2.0 `securityDefinitions` (read via the extensions map) and `$ref`
+# resolution preserve declaration order rather than sorting alphabetically.
+serde_json = { version = "1.0", features = ["preserve_order"] }
 
 # Insertion-order-preserving maps for deterministic output
 indexmap = { version = "2.14", features = ["serde"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ pub struct Cli {
 
     /// Grouping method for endpoints
     #[arg(long, value_enum, default_value = "service")]
-    pub group_by: Option<GroupByArg>,
+    pub group_by: GroupByArg,
 
     /// Generate a flat list without hierarchical structure
     #[arg(long)]
@@ -126,22 +126,27 @@ impl From<SortArg> for SortMethod {
 /// Converts parsed CLI arguments into the internal [`DocConfig`].
 /// Grouping precedence: `--flat` > `--method` > `--group-by` > default (service).
 pub fn build_config(cli: &Cli) -> DocConfig {
-    // Determine grouping method
+    // Determine grouping method.
+    // `--group-by` always has a value (clap default), so it serves as the
+    // base; `--flat` and `--method` are higher-precedence overrides.
     let group_by = if cli.flat {
         GroupBy::Flat
     } else if cli.method {
         GroupBy::Method
-    } else if let Some(group_by) = cli.group_by {
-        group_by.into()
     } else {
-        GroupBy::Service
+        cli.group_by.into()
     };
 
     DocConfig {
         group_by,
         service_filter: cli.service_filter.clone(),
         path_filter: cli.path_filter.clone(),
-        method_filter: cli.method_filter.clone(),
+        // HTTP methods are stored uppercase on each endpoint, so normalize the
+        // filter values too — otherwise `--method-filter get` matches nothing.
+        method_filter: cli
+            .method_filter
+            .as_ref()
+            .map(|methods| methods.iter().map(|m| m.to_uppercase()).collect()),
         exclude_deprecated: cli.exclude_deprecated,
         required_only: cli.required_only,
         detail_level: cli.detail.into(),

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -4,9 +4,34 @@ use std::io::Write;
 use anyhow::Result;
 
 use crate::models::{
-    ApiDocumentation, DetailLevel, DocConfig, Endpoint, GroupBy, Response, Schema,
+    ApiDocumentation, DetailLevel, DocConfig, Endpoint, GroupBy, Response, Schema, SortMethod,
 };
 use crate::utils::{clean_for_id, extract_content_type};
+
+/// Sorts endpoints in place using the configured method.
+///
+/// Every view sorts through this single function so that, within a document,
+/// the table of contents and the body sections always share one ordering
+/// (otherwise TOC anchor links can point to a different sequence than the
+/// sections themselves).
+fn sort_endpoints(endpoints: &mut [&Endpoint], sort_method: &SortMethod) {
+    match sort_method {
+        SortMethod::Alphabetical => {
+            endpoints.sort_by(|a, b| a.path.cmp(&b.path).then(a.method.cmp(&b.method)));
+        }
+        SortMethod::PathLength => {
+            endpoints.sort_by_key(|a| a.path.len());
+        }
+        SortMethod::None => {}
+    }
+}
+
+/// Case-insensitive membership test for `--service-filter` against a service
+/// (tag) name. Mirrors the case-insensitivity of `--method-filter` so that a
+/// case mismatch doesn't silently produce empty output.
+fn service_matches_filter(name: &str, filter: &[String]) -> bool {
+    filter.iter().any(|entry| entry.eq_ignore_ascii_case(name))
+}
 
 /// Renders the documentation to `writer`, dispatching on detail level and grouping mode.
 pub fn generate_markdown<W: Write>(
@@ -58,12 +83,11 @@ fn generate_summary<W: Write>(
         writeln!(writer)?;
     }
 
-    // Filter services if needed
+    // Filter services if needed (case-insensitive)
     let services = if let Some(filter) = &config.service_filter {
-        let filter_set: HashSet<_> = filter.iter().collect();
         doc.services
             .iter()
-            .filter(|s| filter_set.contains(&s.name))
+            .filter(|s| service_matches_filter(&s.name, filter))
             .collect::<Vec<_>>()
     } else {
         doc.services.iter().collect()
@@ -108,20 +132,7 @@ fn generate_summary<W: Write>(
         // Add operation links under each service
         if let Some(endpoints) = service_endpoints.get(&service.name as &str) {
             let mut sorted_ops = endpoints.clone();
-            match config.sort_method {
-                crate::models::SortMethod::Alphabetical => {
-                    sorted_ops.sort_by(|a, b| {
-                        a.operation_id
-                            .clone()
-                            .unwrap_or_default()
-                            .cmp(&b.operation_id.clone().unwrap_or_default())
-                    });
-                }
-                crate::models::SortMethod::PathLength => {
-                    sorted_ops.sort_by_key(|a| a.path.len());
-                }
-                crate::models::SortMethod::None => {}
-            }
+            sort_endpoints(&mut sorted_ops, &config.sort_method);
 
             for endpoint in sorted_ops {
                 let op_name = if let Some(operation_id) = &endpoint.operation_id {
@@ -176,12 +187,11 @@ fn generate_by_service<W: Write>(
         writeln!(writer)?;
     }
 
-    // Filter services if needed
+    // Filter services if needed (case-insensitive)
     let services = if let Some(filter) = &config.service_filter {
-        let filter_set: HashSet<_> = filter.iter().collect();
         doc.services
             .iter()
-            .filter(|s| filter_set.contains(&s.name))
+            .filter(|s| service_matches_filter(&s.name, filter))
             .collect::<Vec<_>>()
     } else {
         doc.services.iter().collect()
@@ -227,20 +237,7 @@ fn generate_by_service<W: Write>(
             // Add operation links under each service
             if let Some(endpoints) = service_endpoints.get(&service.name as &str) {
                 let mut sorted_ops = endpoints.clone();
-                match config.sort_method {
-                    crate::models::SortMethod::Alphabetical => {
-                        sorted_ops.sort_by(|a, b| {
-                            a.summary
-                                .clone()
-                                .unwrap_or_default()
-                                .cmp(&b.summary.clone().unwrap_or_default())
-                        });
-                    }
-                    crate::models::SortMethod::PathLength => {
-                        sorted_ops.sort_by_key(|a| a.path.len());
-                    }
-                    crate::models::SortMethod::None => {}
-                }
+                sort_endpoints(&mut sorted_ops, &config.sort_method);
 
                 for endpoint in sorted_ops {
                     // Extract a shorter title for the TOC entry
@@ -267,15 +264,7 @@ fn generate_by_service<W: Write>(
         if let Some(endpoints) = service_endpoints.get(&service.name as &str) {
             // Sort endpoints as configured
             let mut sorted_endpoints = endpoints.clone();
-            match config.sort_method {
-                crate::models::SortMethod::Alphabetical => {
-                    sorted_endpoints.sort_by(|a, b| a.path.cmp(&b.path));
-                }
-                crate::models::SortMethod::PathLength => {
-                    sorted_endpoints.sort_by_key(|a| a.path.len());
-                }
-                crate::models::SortMethod::None => {}
-            }
+            sort_endpoints(&mut sorted_endpoints, &config.sort_method);
 
             for endpoint in sorted_endpoints {
                 write_endpoint(writer, endpoint, doc, config, true)?;
@@ -327,9 +316,13 @@ fn generate_by_method<W: Write>(
             continue;
         }
 
-        // Apply service filter if configured
+        // Apply service filter if configured (case-insensitive)
         if let Some(services) = &config.service_filter {
-            if !endpoint.services.iter().any(|s| services.contains(s)) {
+            if !endpoint
+                .services
+                .iter()
+                .any(|s| service_matches_filter(s, services))
+            {
                 continue;
             }
         }
@@ -381,15 +374,7 @@ fn generate_by_method<W: Write>(
 
                 // Sort endpoints as configured
                 let mut sorted_endpoints = endpoints.clone();
-                match config.sort_method {
-                    crate::models::SortMethod::Alphabetical => {
-                        sorted_endpoints.sort_by(|a, b| a.path.cmp(&b.path));
-                    }
-                    crate::models::SortMethod::PathLength => {
-                        sorted_endpoints.sort_by_key(|a| a.path.len());
-                    }
-                    crate::models::SortMethod::None => {}
-                }
+                sort_endpoints(&mut sorted_endpoints, &config.sort_method);
 
                 for endpoint in sorted_endpoints {
                     write_endpoint(writer, endpoint, doc, config, true)?;
@@ -441,7 +426,11 @@ fn generate_flat<W: Write>(
                 return false;
             }
             if let Some(services) = &config.service_filter {
-                if !endpoint.services.iter().any(|s| services.contains(s)) {
+                if !endpoint
+                    .services
+                    .iter()
+                    .any(|s| service_matches_filter(s, services))
+                {
                     return false;
                 }
             }
@@ -459,15 +448,7 @@ fn generate_flat<W: Write>(
         })
         .collect();
 
-    match config.sort_method {
-        crate::models::SortMethod::Alphabetical => {
-            endpoints.sort_by(|a, b| a.path.cmp(&b.path).then(a.method.cmp(&b.method)));
-        }
-        crate::models::SortMethod::PathLength => {
-            endpoints.sort_by_key(|a| a.path.len());
-        }
-        crate::models::SortMethod::None => {}
-    }
+    sort_endpoints(&mut endpoints, &config.sort_method);
 
     writeln!(writer, "## Endpoints\n")?;
     for endpoint in endpoints {
@@ -768,7 +749,7 @@ fn collect_schema_rows(
 
     if let Some(all_of) = &schema.all_of {
         for (index, variant) in all_of.iter().enumerate() {
-            let variant_field = format!("{}.allOf[{}]", field, index + 1);
+            let variant_field = format!("{}.allOf[{}]", field, index);
             collect_schema_rows(
                 variant,
                 doc,
@@ -783,7 +764,7 @@ fn collect_schema_rows(
 
     if let Some(one_of) = &schema.one_of {
         for (index, variant) in one_of.iter().enumerate() {
-            let variant_field = format!("{}.oneOf[{}]", field, index + 1);
+            let variant_field = format!("{}.oneOf[{}]", field, index);
             collect_schema_rows(
                 variant,
                 doc,
@@ -798,7 +779,7 @@ fn collect_schema_rows(
 
     if let Some(any_of) = &schema.any_of {
         for (index, variant) in any_of.iter().enumerate() {
-            let variant_field = format!("{}.anyOf[{}]", field, index + 1);
+            let variant_field = format!("{}.anyOf[{}]", field, index);
             collect_schema_rows(
                 variant,
                 doc,

--- a/src/models.rs
+++ b/src/models.rs
@@ -173,8 +173,9 @@ pub struct Components {
     #[serde(rename = "requestBodies")]
     pub request_bodies: Option<HashMap<String, RequestBody>>,
     pub headers: Option<HashMap<String, Header>>,
+    // IndexMap preserves spec order so the Authentication section is deterministic
     #[serde(rename = "securitySchemes")]
-    pub security_schemes: Option<HashMap<String, SecurityScheme>>,
+    pub security_schemes: Option<IndexMap<String, SecurityScheme>>,
     pub links: Option<HashMap<String, Link>>,
     pub callbacks: Option<HashMap<String, Callback>>,
     #[serde(flatten)]
@@ -356,6 +357,6 @@ pub struct ApiDocumentation {
     pub services: Vec<Service>,
     pub endpoints: Vec<Endpoint>,
     pub servers: Vec<String>,
-    pub security_schemes: HashMap<String, String>,
+    pub security_schemes: IndexMap<String, String>,
     pub schemas: IndexMap<String, Schema>,
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,7 +39,12 @@ pub fn parse_openapi<P: AsRef<Path>>(path: P) -> Result<ApiDocumentation> {
             let security_schemes = extract_security_schemes(&spec);
             debug!("Extracted {} security schemes", security_schemes.len());
 
-            let endpoints = extract_endpoints(&spec, &services);
+            // Serialize the spec to JSON once so `$ref` resolution can navigate
+            // it without re-serializing the (potentially multi-MB) spec per ref.
+            let spec_json = serde_json::to_value(&spec)
+                .context("Failed to serialize OpenAPI spec for reference resolution")?;
+
+            let endpoints = extract_endpoints(&spec, &spec_json, &services);
             debug!("Extracted {} endpoints", endpoints.len());
             let schemas = extract_schemas(&spec);
             debug!("Extracted {} reusable schemas", schemas.len());
@@ -196,7 +201,11 @@ fn extract_services(spec: &OpenApiSpec) -> Vec<Service> {
 /// Flattens every operation under `paths` into an [`Endpoint`], merging
 /// path-level and operation-level parameters, resolving `$ref`s, and
 /// representing an OpenAPI 3.0 `requestBody` as a synthetic `body` parameter.
-fn extract_endpoints(spec: &OpenApiSpec, services: &[Service]) -> Vec<Endpoint> {
+fn extract_endpoints(
+    spec: &OpenApiSpec,
+    spec_json: &serde_json::Value,
+    services: &[Service],
+) -> Vec<Endpoint> {
     let mut endpoints = Vec::new();
 
     // A map of service names to ensure all endpoints are associated with valid services
@@ -221,7 +230,7 @@ fn extract_endpoints(spec: &OpenApiSpec, services: &[Service]) -> Vec<Endpoint> 
             .map(|params| {
                 params
                     .iter()
-                    .filter_map(|p| resolve_parameter_ref(spec, p))
+                    .filter_map(|p| resolve_parameter_ref(spec_json, p))
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
@@ -261,7 +270,7 @@ fn extract_endpoints(spec: &OpenApiSpec, services: &[Service]) -> Vec<Endpoint> 
 
                 if let Some(op_params) = &operation.parameters {
                     for param in op_params {
-                        if let Some(resolved_param) = resolve_parameter_ref(spec, param) {
+                        if let Some(resolved_param) = resolve_parameter_ref(spec_json, param) {
                             parameters.push(resolved_param);
                         }
                     }
@@ -287,7 +296,7 @@ fn extract_endpoints(spec: &OpenApiSpec, services: &[Service]) -> Vec<Endpoint> 
                     .responses
                     .iter()
                     .map(|(status_code, response)| {
-                        let resolved = resolve_response_ref(spec, response)
+                        let resolved = resolve_response_ref(spec_json, response)
                             .unwrap_or_else(|| response.clone());
                         (status_code.clone(), resolved)
                     })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,13 @@
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 use crate::models::{OpenApiSpec, Parameter, Response};
 
-/// Resolves a JSON reference within the OpenAPI specification
-pub fn resolve_ref(spec: &OpenApiSpec, reference: &str) -> Option<serde_json::Value> {
+/// Resolves a JSON reference within a pre-serialized OpenAPI specification.
+///
+/// `spec_json` is the spec serialized to a [`serde_json::Value`] once by the
+/// caller (see [`parse_openapi`](crate::parser::parse_openapi)); resolution
+/// only navigates it, so it never re-serializes the spec per `$ref`.
+pub fn resolve_ref(spec_json: &serde_json::Value, reference: &str) -> Option<serde_json::Value> {
     if !reference.starts_with("#/") {
         return None; // We only support internal references for now
     }
@@ -12,11 +16,8 @@ pub fn resolve_ref(spec: &OpenApiSpec, reference: &str) -> Option<serde_json::Va
     let path = &reference[2..];
     let components = path.split('/');
 
-    // Start with the spec as a JSON value
-    let spec_json = serde_json::to_value(spec).ok()?;
-
     // Navigate the path
-    let mut current = &spec_json;
+    let mut current = spec_json;
     for component in components {
         // Handle escaped JSON pointer components
         let unescaped = component.replace("~1", "/").replace("~0", "~");
@@ -46,10 +47,13 @@ pub fn resolve_ref(spec: &OpenApiSpec, reference: &str) -> Option<serde_json::Va
 }
 
 /// Resolves a parameter reference to a concrete parameter
-pub fn resolve_parameter_ref(spec: &OpenApiSpec, parameter: &Parameter) -> Option<Parameter> {
+pub fn resolve_parameter_ref(
+    spec_json: &serde_json::Value,
+    parameter: &Parameter,
+) -> Option<Parameter> {
     if let Some(extensions) = parameter.extensions.get("$ref") {
         if let Some(reference) = extensions.as_str() {
-            if let Some(resolved) = resolve_ref(spec, reference) {
+            if let Some(resolved) = resolve_ref(spec_json, reference) {
                 return serde_json::from_value(resolved).ok();
             }
         }
@@ -58,10 +62,13 @@ pub fn resolve_parameter_ref(spec: &OpenApiSpec, parameter: &Parameter) -> Optio
 }
 
 /// Resolves a response reference to a concrete response
-pub fn resolve_response_ref(spec: &OpenApiSpec, response: &Response) -> Option<Response> {
+pub fn resolve_response_ref(
+    spec_json: &serde_json::Value,
+    response: &Response,
+) -> Option<Response> {
     if let Some(extensions) = response.extensions.get("$ref") {
         if let Some(reference) = extensions.as_str() {
-            if let Some(resolved) = resolve_ref(spec, reference) {
+            if let Some(resolved) = resolve_ref(spec_json, reference) {
                 return serde_json::from_value(resolved).ok();
             }
         }
@@ -110,9 +117,12 @@ pub fn extract_servers(spec: &OpenApiSpec) -> Vec<String> {
     servers
 }
 
-/// Extracts security schemes from the OpenAPI spec
-pub fn extract_security_schemes(spec: &OpenApiSpec) -> HashMap<String, String> {
-    let mut schemes = HashMap::new();
+/// Extracts security schemes from the OpenAPI spec.
+///
+/// Returns an [`IndexMap`] so the `## Authentication` section is emitted in a
+/// stable order, preserving the output-determinism invariant.
+pub fn extract_security_schemes(spec: &OpenApiSpec) -> IndexMap<String, String> {
+    let mut schemes = IndexMap::new();
 
     // OpenAPI 3.0+: components.securitySchemes
     if let Some(components) = &spec.components {
@@ -152,14 +162,29 @@ pub fn extract_security_schemes(spec: &OpenApiSpec) -> HashMap<String, String> {
     schemes
 }
 
-/// Cleans a string for use as an ID or anchor in Markdown
+/// Cleans a string for use as an ID or anchor in Markdown.
+///
+/// Lowercases, maps every run of non-`[alphanumeric-_]` characters to a single
+/// dash, and trims leading/trailing dashes. A single `.replace("--", "-")` only
+/// collapses pairs, so runs of 3+ dashes (e.g. from `"a///b"`) would survive;
+/// folding character-by-character collapses any-length runs in one pass.
 pub fn clean_for_id(input: &str) -> String {
-    input
-        .to_lowercase()
-        .replace(|c: char| !c.is_alphanumeric() && c != '-' && c != '_', "-")
-        .replace("--", "-")
-        .trim_matches('-')
-        .to_string()
+    let mut result = String::with_capacity(input.len());
+    let mut last_was_dash = false;
+
+    for c in input.to_lowercase().chars() {
+        if c.is_alphanumeric() || c == '_' {
+            result.push(c);
+            last_was_dash = false;
+        } else if !last_was_dash {
+            // Any disallowed character (including a literal '-') folds into a
+            // single separating dash, collapsing consecutive runs.
+            result.push('-');
+            last_was_dash = true;
+        }
+    }
+
+    result.trim_matches('-').to_string()
 }
 
 /// Extracts the primary content type from responses
@@ -176,4 +201,31 @@ pub fn extract_content_type(response: &Response) -> Option<String> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clean_for_id;
+
+    #[test]
+    fn clean_for_id_basic_cases() {
+        assert_eq!(clean_for_id("Pets_ListPets"), "pets_listpets");
+        assert_eq!(clean_for_id("GET /pets"), "get-pets");
+        assert_eq!(clean_for_id("list-pets"), "list-pets");
+    }
+
+    // Regression test for #15: a single `.replace("--", "-")` left runs of 3+
+    // dashes intact; folding must collapse any-length runs to one dash.
+    #[test]
+    fn clean_for_id_collapses_long_dash_runs() {
+        assert_eq!(clean_for_id("a///b"), "a-b");
+        assert_eq!(clean_for_id("a / / b"), "a-b");
+        assert_eq!(clean_for_id("foo----bar"), "foo-bar");
+    }
+
+    #[test]
+    fn clean_for_id_trims_edge_dashes() {
+        assert_eq!(clean_for_id("/pets/"), "pets");
+        assert_eq!(clean_for_id("**bold**"), "bold");
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,6 +6,7 @@ const OAS3: &str = "tests/fixtures/petstore_oas3.json";
 const OAS2: &str = "tests/fixtures/petstore_oas2.json";
 const OAS3_SCHEMA_REFS: &str = "tests/fixtures/schema_refs_oas3.json";
 const OAS3_MULTI_AUTH: &str = "tests/fixtures/multi_auth_oas3.json";
+const OAS2_MULTI_AUTH: &str = "tests/fixtures/multi_auth_oas2.json";
 
 fn vimanam() -> Command {
     Command::cargo_bin("vimanam").unwrap()
@@ -297,6 +298,32 @@ fn multiple_security_schemes_preserve_spec_order() {
     for _ in 0..4 {
         assert_eq!(output, run(), "authentication order differed between runs");
     }
+}
+
+// Companion to #16 for OpenAPI 2.0: `securityDefinitions` are read through the
+// extensions map, so they only preserve spec order with serde_json's
+// `preserve_order` feature (otherwise they sort alphabetically). The schemes
+// are declared zebra/apiKey/middle, which is not alphabetical.
+#[test]
+fn oas2_security_schemes_preserve_spec_order() {
+    let output = String::from_utf8(
+        vimanam()
+            .arg(OAS2_MULTI_AUTH)
+            .arg("--include-auth")
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+
+    let zebra = output.find("zebraAuth").expect("zebraAuth missing");
+    let api_key = output.find("apiKey").expect("apiKey missing");
+    let middle = output.find("middleAuth").expect("middleAuth missing");
+
+    assert!(
+        zebra < api_key && api_key < middle,
+        "OAS2 security schemes not in spec order: {output}"
+    );
 }
 
 // Regression test for #20: `--group-by method` must behave like `--method`,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 const OAS3: &str = "tests/fixtures/petstore_oas3.json";
 const OAS2: &str = "tests/fixtures/petstore_oas2.json";
 const OAS3_SCHEMA_REFS: &str = "tests/fixtures/schema_refs_oas3.json";
+const OAS3_MULTI_AUTH: &str = "tests/fixtures/multi_auth_oas3.json";
 
 fn vimanam() -> Command {
     Command::cargo_bin("vimanam").unwrap()
@@ -96,6 +97,32 @@ fn method_filter_excludes_other_methods() {
         .success()
         .stdout(predicate::str::contains("Pets_ListPets"))
         .stdout(predicate::str::contains("Pets_CreatePet").not());
+}
+
+// Regression test for #13: methods are stored uppercase, so a lowercase
+// `--method-filter` value used to match nothing and silently empty the output.
+#[test]
+fn method_filter_is_case_insensitive() {
+    vimanam()
+        .arg(OAS3)
+        .args(["--detail", "basic", "--method-filter", "get"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pets_ListPets"))
+        .stdout(predicate::str::contains("Pets_CreatePet").not());
+}
+
+// Regression test for #19: a case-mismatched `--service-filter` used to
+// silently omit all endpoints.
+#[test]
+fn service_filter_is_case_insensitive() {
+    vimanam()
+        .arg(OAS3)
+        .args(["--detail", "basic", "--service-filter", "pets"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pets_ListPets"))
+        .stdout(predicate::str::contains("Store_ListOrders").not());
 }
 
 #[test]
@@ -233,9 +260,90 @@ fn full_detail_expands_schema_refs_into_tables() {
             "| `request.category.id` | string | Yes | Category identifier |",
         ))
         .stdout(predicate::str::contains(
-            "| `response.allOf[2].id` | string | Yes | Pet identifier |",
+            "| `response.allOf[1].id` | string | Yes | Pet identifier |",
         ))
-        .stdout(predicate::str::contains("request.variant.oneOf[1]"));
+        .stdout(predicate::str::contains("request.variant.oneOf[0]"));
+}
+
+// Regression test for #16: the Authentication section is emitted in spec
+// (file) order, not the random order of a HashMap, and is stable across runs.
+#[test]
+fn multiple_security_schemes_preserve_spec_order() {
+    let run = || {
+        String::from_utf8(
+            vimanam()
+                .arg(OAS3_MULTI_AUTH)
+                .arg("--include-auth")
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+    };
+
+    let output = run();
+
+    let zebra = output.find("zebraAuth").expect("zebraAuth missing");
+    let api_key = output.find("apiKeyAuth").expect("apiKeyAuth missing");
+    let middle = output.find("middleAuth").expect("middleAuth missing");
+
+    // Schemes appear in the order they are declared in the spec file.
+    assert!(
+        zebra < api_key && api_key < middle,
+        "security schemes not in spec order: {output}"
+    );
+
+    // And that order is deterministic across runs.
+    for _ in 0..4 {
+        assert_eq!(output, run(), "authentication order differed between runs");
+    }
+}
+
+// Regression test for #20: `--group-by method` must behave like `--method`,
+// producing HTTP-method sections rather than service sections.
+#[test]
+fn group_by_method_groups_by_http_method() {
+    vimanam()
+        .arg(OAS3)
+        .args(["--detail", "basic", "--group-by", "method"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("## GET"))
+        .stdout(predicate::str::contains("## POST"));
+}
+
+// Regression test for #18: under alphabetical sort the TOC operation links must
+// appear in the same order as the endpoint sections in the body.
+#[test]
+fn toc_order_matches_body_order() {
+    let output = String::from_utf8(
+        vimanam()
+            .arg(OAS3)
+            .args(["--detail", "basic", "--sort", "alpha"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+
+    // The Pets service has CreatePet (POST /pets) and ListPets (GET /pets);
+    // sorted by path then method, GET sorts before POST, so ListPets precedes
+    // CreatePet in both the TOC and the body.
+    let toc_list = output
+        .find("[Pets_ListPets]")
+        .expect("ListPets TOC link missing");
+    let toc_create = output
+        .find("[Pets_CreatePet]")
+        .expect("CreatePet TOC link missing");
+    let body_list = output
+        .find("### Pets_ListPets")
+        .expect("ListPets section missing");
+    let body_create = output
+        .find("### Pets_CreatePet")
+        .expect("CreatePet section missing");
+
+    assert!(toc_list < toc_create, "TOC order unexpected: {output}");
+    assert!(body_list < body_create, "body order unexpected: {output}");
 }
 
 #[test]

--- a/tests/fixtures/multi_auth_oas2.json
+++ b/tests/fixtures/multi_auth_oas2.json
@@ -1,0 +1,36 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Multi Auth Legacy API",
+    "version": "1.0.0"
+  },
+  "tags": [{ "name": "Pets", "description": "Pet operations" }],
+  "paths": {
+    "/pets": {
+      "get": {
+        "tags": ["Pets"],
+        "summary": "List pets",
+        "operationId": "Pets_ListPets",
+        "responses": {
+          "200": { "description": "A list of pets" }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "zebraAuth": {
+      "type": "oauth2",
+      "description": "Zebra OAuth2"
+    },
+    "apiKey": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header",
+      "description": "API key auth"
+    },
+    "middleAuth": {
+      "type": "basic",
+      "description": "Basic auth"
+    }
+  }
+}

--- a/tests/fixtures/multi_auth_oas3.json
+++ b/tests/fixtures/multi_auth_oas3.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Multi Auth API",
+    "version": "1.0.0"
+  },
+  "tags": [{ "name": "Pets", "description": "Pet operations" }],
+  "paths": {
+    "/pets": {
+      "get": {
+        "tags": ["Pets"],
+        "summary": "List pets",
+        "operationId": "Pets_ListPets",
+        "responses": {
+          "200": { "description": "A list of pets" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "zebraAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Zebra bearer token"
+      },
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "header",
+        "description": "API key"
+      },
+      "middleAuth": {
+        "type": "oauth2",
+        "description": "OAuth2 flow"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

A batch of correctness, determinism, and performance fixes for the open issues, plus regression tests and a `0.3.0` → `0.4.0` version bump.

| # | Issue | Fix |
|---|-------|-----|
| #13 | `--method-filter` case-sensitive | Normalize filter values to uppercase (methods are stored uppercase) |
| #15 | `clean_for_id` left 3+ dash runs | Fold any-length separator runs into a single dash in one pass |
| #16 | `security_schemes` non-deterministic | `HashMap` → `IndexMap` for source + IR, so Authentication output is in spec order |
| #17 | `resolve_ref` re-serialized whole spec per `$ref` | Serialize the spec to JSON once per parse |
| #18 | TOC sort key ≠ body sort key | Single shared `sort_endpoints` helper across all views |
| #19 | `--service-filter` case-sensitive | Case-insensitive comparison |
| #20 | `--group-by` dead `Option` wrapper | Make it non-`Option` (it always has a clap default); drop the unreachable branch |
| #21 | 1-based `allOf`/`oneOf`/`anyOf` indices | Changed to 0-based to match JSON Pointer/jq conventions |

## Tests

- New `clean_for_id` unit tests (basic cases, long dash runs, edge trimming)
- New integration tests: case-insensitive `--method-filter` / `--service-filter`, deterministic multi-scheme auth order, TOC/body order consistency, `--group-by method`
- New fixture `tests/fixtures/multi_auth_oas3.json`
- Updated the `#21` fixture expectations to 0-based
- `cargo test`, `cargo clippy --all-targets`, `cargo fmt` all clean (25 tests pass)

## Versioning

The #21 output-format change and the #16/#18 output reordering are not backward-compatible for anyone diffing generated docs, so this is a minor bump (`0.3.0` → `0.4.0`) rather than a patch. Cargo.toml, Cargo.lock, and CHANGELOG updated. The release tag must be `v0.4.0`.

Closes #13
Closes #15
Closes #16
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Version 0.4.0

* **Bug Fixes**
  * Fixed stderr logging for fatal errors
  * Improved separator collapsing in ID generation
  * Fixed schema composition field indexing (now 0-based)

* **Changed**
  * Case-insensitive `--method-filter` and `--service-filter` options
  * Deterministic ordering for authentication schemes
  * Consistent endpoint ordering in documentation

* **Performance**
  * Improved `$ref` resolution speed through optimized parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->