### PR TITLE
Project health: Dependabot, community files, release archives + checksums

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report incorrect or unexpected behavior
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear description of what's wrong.
+
+## To reproduce
+
+The exact command and flags you ran:
+
+```bash
+vimanam spec.json --detail full --group-by path ...
+```
+
+- **OpenAPI version of the input:** 2.0 (Swagger) / 3.0+ / not sure
+- If possible, attach or paste a **minimal spec** that reproduces the issue
+  (the smallest input that still shows the problem).
+
+## Expected vs actual
+
+**Expected:** what you thought the output / behavior would be.
+
+**Actual:** what happened instead (paste the relevant Markdown output or error;
+running with `RUST_LOG=debug` can add useful detail).
+
+## Environment
+
+- `vimanam --version`:
+- Installed via: crates.io / prebuilt binary / built from source
+- OS:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/nrynss/vimanam/security/advisories/new
+    about: Please report security issues privately — see SECURITY.md. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Suggest a new capability or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem / motivation
+
+What are you trying to do, and where does Vimanam fall short today? Concrete use
+cases help a lot (e.g. "I want to feed a filtered slice of a 3 MB spec to an
+LLM" or "my specs are YAML").
+
+## Proposed solution
+
+What would you like Vimanam to do? If it's a new flag, sketch the name and
+behavior, e.g.:
+
+```bash
+vimanam spec.json --new-flag value
+```
+
+## Alternatives considered
+
+Other approaches, workarounds you're using now, or related tools.
+
+## Additional context
+
+Anything else — example specs, expected output, links.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Thanks for contributing! Keep PRs focused on one logical change.
+See CONTRIBUTING.md for the development loop and conventions.
+-->
+
+## Summary
+
+What does this change do, and why?
+
+Closes #
+
+## Checklist
+
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo test` passes
+- [ ] Tests added/updated for behavior changes
+- [ ] `CHANGELOG.md` `[Unreleased]` updated (for user-facing changes)
+- [ ] MSRV (Rust 1.85) still builds, or the PR intentionally raises it
+
+## Notes for reviewers
+
+Anything worth calling out — trade-offs, follow-ups, areas to scrutinize.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Rust crate dependencies
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Roll minor/patch bumps into a single PR to cut review noise.
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Pinned GitHub Actions in ci.yml / release.yml (kept SHA-pinned; Dependabot
+  # updates the SHA and the trailing `# vX.Y.Z` version comment together).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
             --notes "$NOTES
 
           ---
-          Binaries for Linux, macOS (Intel & Apple Silicon), and Windows are attached. Also available via \`cargo install vimanam\`."
+          Compressed archives (\`.tar.gz\` for Linux/macOS, \`.zip\` for Windows) with per-asset \`.sha256\` checksums for Linux, macOS (Intel & Apple Silicon), and Windows are attached. Also available via \`cargo install vimanam\`."
 
   publish-crate:
     name: Publish to crates.io
@@ -88,25 +88,21 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact_name: vimanam
-            asset_name: vimanam-linux-x86_64
 
           # Windows (x86_64)
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact_name: vimanam.exe
-            asset_name: vimanam-windows-x86_64.exe
 
           # macOS (Intel x86_64)
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: vimanam
-            asset_name: vimanam-macos-x86_64
 
           # macOS (ARM64 / Apple Silicon)
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact_name: vimanam
-            asset_name: vimanam-macos-arm64
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -122,10 +118,36 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Upload Release Asset
+      - name: Package and upload release archive
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp "target/${{ matrix.target }}/release/${{ matrix.artifact_name }}" "${{ matrix.asset_name }}"
-          gh release upload "${{ github.ref_name }}" "${{ matrix.asset_name }}" --clobber
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          BIN="${{ matrix.artifact_name }}"
+          TARGET="${{ matrix.target }}"
+          # cargo-binstall-friendly name: vimanam-<version>-<target-triple>
+          STAGE="vimanam-${VERSION}-${TARGET}"
+
+          # Stage the binary alongside the docs/license.
+          mkdir "$STAGE"
+          cp "target/${TARGET}/release/${BIN}" "$STAGE/"
+          cp README.md LICENSE "$STAGE/"
+
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            ARCHIVE="${STAGE}.zip"
+            7z a "$ARCHIVE" "$STAGE" >/dev/null
+          else
+            ARCHIVE="${STAGE}.tar.gz"
+            tar -czf "$ARCHIVE" "$STAGE"
+          fi
+
+          # Per-asset SHA256 checksum (sha256sum on Linux/Windows-bash, shasum on macOS).
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
+          else
+            shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256"
+          fi
+
+          gh release upload "${{ github.ref_name }}" "$ARCHIVE" "${ARCHIVE}.sha256" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,4 +150,4 @@ jobs:
             shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256"
           fi
 
-          gh release upload "${{ github.ref_name }}" "$ARCHIVE" "${ARCHIVE}.sha256" --clobber
+          gh release upload "$GITHUB_REF_NAME" "$ARCHIVE" "${ARCHIVE}.sha256" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ output.md
 !README.md
 !CLAUDE.md
 !CHANGELOG.md
+!SECURITY.md
+!CONTRIBUTING.md
+!CODE_OF_CONDUCT.md
+!.github/**/*.md
 examples/*.md
 tests/output/
 openapi*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Release artifacts are now compressed archives instead of bare binaries:
+  `.tar.gz` for Linux/macOS and `.zip` for Windows, named
+  `vimanam-<version>-<target-triple>` (cargo-binstall-friendly) and bundling the
+  binary, `README.md`, and `LICENSE`. Each archive ships with a matching
+  `.sha256` checksum, which downstream package managers need to verify
+  downloads (#24)
+
 ## [0.5.0] - 2026-06-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ cargo test optional_request_body     # run a single test by name substring
 cargo fmt && cargo clippy            # format / lint
 ```
 
-There is no CI for build/test — the only workflow (`.github/workflows/release.yml`) builds cross-platform binaries when a `v*` tag is pushed.
+CI (`.github/workflows/ci.yml`) runs `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` on every push and pull request, plus an MSRV build on Rust 1.85. The release workflow (`.github/workflows/release.yml`) fires on a `v*` tag: it verifies the tag matches the `Cargo.toml` version, publishes to crates.io, and builds cross-platform binaries packaged as compressed archives with SHA256 checksums.
 
 Real-world specs for manual testing may live at the repo root: `swagger.json` (small), `openapi.json` and `openapiv2.swagger.json` (~3 MB each). These and the root `*.md` sample outputs (`summary*.md`, `basicoutput.md`, `fulloutput.md`, etc.) are gitignored local artifacts — they won't exist in a fresh clone, and they're not docs to edit.
 
@@ -28,7 +28,7 @@ Pipeline in `main.rs`: CLI args → `config::build_config` → `parser::parse_op
 - `src/config.rs` — clap `Cli` struct and `*Arg` value enums, converted into the internal `DocConfig`. Grouping precedence in `build_config`: `--flat` > `--method` > `--group-by` > default (service).
 - `src/models.rs` — two layers of types: serde structs mirroring the OpenAPI spec (`OpenApiSpec`, `Operation`, `Parameter`, ...) and the spec-version-agnostic intermediate representation (`ApiDocumentation`, `Endpoint`, `Service`, `DocConfig` enums). The IR is what the generator consumes.
 - `src/parser.rs` — deserializes the spec and flattens it into the IR. Handles both versions via serde alias (`swagger`/`openapi` field), derives "services" from tags (falling back to per-operation tags, then a default `"API"` service), merges path-level and operation-level parameters, represents an OpenAPI 3.0 `requestBody` as a synthetic `body` parameter, and resolves `$ref`s during extraction. On deserialize failure it re-parses as generic JSON to produce targeted error messages.
-- `src/markdown.rs` — one `generate_by_*` function per grouping mode, all delegating per-endpoint rendering to `write_endpoint`, which branches on `DetailLevel`. Writes through a generic `W: Write` (file or stdout).
+- `src/markdown/` — markdown generation, split into submodules behind the `generate_markdown` entry point in `mod.rs` (which also holds the `--max-tokens` budget logic that re-renders at progressively lower detail). `views.rs` has one `generate_*` function per grouping mode plus shared preamble/filter/sort helpers; `endpoint.rs` renders a single endpoint, branching on `DetailLevel`; `schema.rs` renders schema field tables; `examples.rs` renders example blocks. Writes through a generic `W: Write` (file or stdout).
 - `src/utils.rs` — `$ref` resolution against `components`/`definitions`, server URL and security-scheme extraction, anchor-id cleaning, response content-type detection.
 
 Unknown spec fields are preserved via `#[serde(flatten)] extensions` maps on most model structs rather than failing deserialization.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Code of Conduct
+
+## Our pledge
+
+We want Vimanam to be a welcoming, harassment-free project for everyone,
+regardless of background or identity. Contributors and maintainers pledge to
+make participation a respectful and constructive experience.
+
+## Our standards
+
+Examples of behavior that helps the community:
+
+- Being respectful of differing viewpoints and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Focusing on what is best for the project and its users.
+
+Unacceptable behavior includes harassment, insulting or derogatory comments,
+personal or political attacks, publishing others' private information without
+consent, and other conduct that would reasonably be considered inappropriate.
+
+## Standard adopted
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1. The full text is available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>, and its
+[FAQ](https://www.contributor-covenant.org/faq) answers common questions.
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests,
+discussions) and when an individual is representing the project in public spaces.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported privately to the project
+maintainer via a [GitHub security advisory](https://github.com/nrynss/vimanam/security/advisories/new)
+or by contacting [@nrynss](https://github.com/nrynss). All reports will be
+reviewed and handled discreetly. Maintainers are responsible for clarifying
+standards and may take appropriate corrective action in response to behavior
+they deem inappropriate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to Vimanam
+
+Thanks for your interest in improving Vimanam! This is a small project, so the
+process is light. Bug reports, feature ideas, and pull requests are all welcome.
+
+## Getting started
+
+Vimanam is a standard Rust (edition 2021) CLI. You need a Rust toolchain; the
+minimum supported version (MSRV) is **1.85**.
+
+```bash
+git clone https://github.com/nrynss/vimanam.git
+cd vimanam
+cargo build
+cargo run -- path/to/spec.json -o out.md
+```
+
+## Development loop
+
+Before opening a pull request, run the same checks CI enforces:
+
+```bash
+cargo fmt --check                          # formatting
+cargo clippy --all-targets -- -D warnings  # lint (warnings are errors)
+cargo test                                 # integration tests (tests/cli.rs)
+```
+
+CI also builds against the MSRV (Rust 1.85) on every pull request, so avoid
+language or dependency features newer than that unless you intend to raise the
+MSRV deliberately (and call it out in the PR).
+
+`cargo test` runs the integration suite in `tests/cli.rs` against the fixtures
+in `tests/fixtures/`. Run a single test by name substring, e.g.
+`cargo test group_by_path`.
+
+## Conventions worth knowing
+
+- **Deterministic output is a tested invariant.** `output_is_deterministic` in
+  `tests/cli.rs` asserts byte-identical output across runs. Order-sensitive maps
+  (`paths`, `responses`, `content`, examples) use `IndexMap` — don't swap them
+  back to `HashMap`.
+- **Unknown spec fields are preserved**, not rejected: model structs carry a
+  `#[serde(flatten)] extensions` map so vendor (`x-*`) fields survive.
+- **`$ref`s are resolved during parsing**, not at render time (see
+  `resolve_*_ref` in `src/utils.rs`).
+- **Keep the CLI surface honest** — don't add a flag that only partially works;
+  the project has a history of removing placeholder flags.
+- **New tracked Markdown or fixtures need a `.gitignore` exception.** The blanket
+  `*.md` ignore allowlists specific files (`README.md`, `CONTRIBUTING.md`,
+  `tests/fixtures/**`, `.github/**/*.md`, …); add yours if you create one.
+
+## Pull requests
+
+- Keep changes focused; one logical change per PR is easiest to review.
+- Add or update tests for behavior changes.
+- Update the `## [Unreleased]` section of [`CHANGELOG.md`](CHANGELOG.md)
+  (the project follows [Keep a Changelog](https://keepachangelog.com/) and
+  [Semantic Versioning](https://semver.org/)).
+- Reference the issue you're addressing (e.g. "Closes #12").
+
+## Reporting bugs / requesting features
+
+Open an issue using the templates. For security issues, please follow
+[`SECURITY.md`](SECURITY.md) instead of filing a public issue.
+
+By contributing, you agree that your contributions are licensed under the
+project's [Apache-2.0 license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ cargo install vimanam
 
 ### Prebuilt binaries
 
-Download the binary for your platform (Linux, macOS Intel/ARM64, Windows) from the
+Download the archive for your platform (Linux, macOS Intel/ARM64, Windows) from the
 [latest release](https://github.com/nrynss/vimanam/releases/latest) — no Rust toolchain needed.
+Archives are named `vimanam-<version>-<target-triple>.tar.gz` (`.zip` on Windows) and ship with
+a matching `.sha256` checksum; each bundles the binary, `README.md`, and `LICENSE`. Extract it and
+put the `vimanam` binary on your `PATH`.
 
 ### From source
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported versions
+
+Vimanam is pre-1.0 and ships fixes only against the latest release. Security
+fixes land on `main` and go out in the next version.
+
+| Version | Supported |
+| ------- | --------- |
+| latest release (`0.5.x`) | ✅ |
+| older releases | ❌ |
+
+## Reporting a vulnerability
+
+Please report security issues **privately** — do not open a public issue for a
+suspected vulnerability.
+
+Use GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability):
+go to the repository's **Security** tab → **Report a vulnerability**. This opens
+a private advisory visible only to the maintainers.
+
+When reporting, please include:
+
+- the version (`vimanam --version`) and platform,
+- a description of the issue and its impact,
+- a minimal spec or input that reproduces it, if applicable,
+- any suggested remediation.
+
+You can expect an initial acknowledgement within a few days. Because Vimanam is
+a small, single-maintainer project, please allow reasonable time for a fix
+before any public disclosure.
+
+## Scope notes
+
+Vimanam reads an OpenAPI/Swagger document and writes Markdown. The most relevant
+classes of issue are input-handling problems triggered by a malicious or
+malformed spec (for example: excessive resource use, panics, or path/`$ref`
+handling that escapes expectations). Reports that demonstrate such behavior from
+a crafted input are in scope.


### PR DESCRIPTION
Project-health pass addressing three tracked issues plus a docs-accuracy fix. No source-code changes — repo metadata, CI/release config, and docs only.

## Closes #36 — community health files
- `SECURITY.md` — private vulnerability reporting via GitHub Security advisories (no email exposed).
- `CONTRIBUTING.md` — dev loop (`fmt`/`clippy -D warnings`/`test`), MSRV 1.85, and the determinism / `$ref` / extensions conventions.
- `CODE_OF_CONDUCT.md` — adopts the Contributor Covenant by reference.
- `.github/ISSUE_TEMPLATE/` (bug + feature + `config.yml` routing security reports privately) and `.github/PULL_REQUEST_TEMPLATE.md`.
- `.gitignore` gains exceptions so the blanket `*.md` rule doesn't drop these.

## Closes #35 — Dependabot
- `.github/dependabot.yml`: weekly `cargo` updates (minor/patch grouped) and `github-actions` updates for the SHA-pinned actions. Dependabot PRs run through existing CI.

## Closes #24 — release archives + checksums
- Release assets are now `.tar.gz` (Linux/macOS) / `.zip` (Windows) archives named `vimanam-<version>-<target-triple>` (cargo-binstall-friendly), bundling binary + `README.md` + `LICENSE`, each with a matching `.sha256`. Prerequisite for the packaging issues (#25–#31).
- README install section + CHANGELOG updated.
- Optional extra targets (`aarch64-linux`, `musl`) from #24 left as a follow-up to avoid cross-compilation complexity.

## Docs accuracy
- `CLAUDE.md`: corrected the stale "no CI for build/test" note (CI exists: fmt, clippy `-D warnings`, test, MSRV build), documented the release workflow's crates.io publish, and updated the architecture section (`markdown.rs` is now the `markdown/` module).

## Verification
- All YAML (`dependabot.yml`, `release.yml`, issue `config.yml`) parses.
- Confirmed the new tracked Markdown files stage despite the `*.md` ignore.
- The `release.yml` change only executes on the next `v*` tag (nothing runs from this PR); it's been reviewed for shell correctness (`set -euo pipefail`, `7z` on Windows runners, `sha256sum`/`shasum` fallback for macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Code of Conduct, Contributing Guide, and Security Policy
  * Updated prebuilt binary installation instructions (now distributed as compressed archives with .sha256 checksums)

* **Chores**
  * Added GitHub issue and pull request templates
  * Configured Dependabot for weekly dependency updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->