### PR TITLE
Ref-aware, tolerant parsing + deterministic auth output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ clap = { version = "4.6", features = ["derive"] }
 
 # JSON parsing
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+# preserve_order keeps serde_json::Value objects in spec order (deterministic output)
+serde_json = { version = "1.0", features = ["preserve_order"] }
 
 # Insertion-order-preserving maps for deterministic output
 indexmap = { version = "2.14", features = ["serde"] }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -546,7 +546,10 @@ fn write_endpoint<W: Write>(
                 writeln!(
                     writer,
                     "| `{}` | {} | {} | {} |",
-                    param.name, param.parameter_in, required_str, desc
+                    param.name(),
+                    param.location(),
+                    required_str,
+                    desc
                 )?;
             }
         }
@@ -570,7 +573,7 @@ fn write_endpoint<W: Write>(
             let body_param = endpoint
                 .parameters
                 .iter()
-                .find(|p| p.parameter_in == "body" && p.schema.is_some());
+                .find(|p| p.location() == "body" && p.schema.is_some());
 
             if let Some(param) = body_param {
                 if let Some(schema) = &param.schema {

--- a/src/models.rs
+++ b/src/models.rs
@@ -64,6 +64,9 @@ pub struct PathItem {
     pub trace: Option<Operation>,
     #[serde(rename = "parameters", skip_serializing_if = "Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
+    // Captures a path-item-level `$ref` (and any extensions) so it can be resolved.
+    #[serde(flatten)]
+    pub extensions: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -76,6 +79,8 @@ pub struct Operation {
     pub parameters: Option<Vec<Parameter>>,
     #[serde(rename = "requestBody", skip_serializing_if = "Option::is_none")]
     pub request_body: Option<RequestBody>,
+    // Defaulted so an operation missing `responses` doesn't fail the whole parse.
+    #[serde(default)]
     pub responses: IndexMap<String, Response>,
     pub deprecated: Option<bool>,
     #[serde(rename = "security", skip_serializing_if = "Option::is_none")]
@@ -84,24 +89,65 @@ pub struct Operation {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Parameter {
-    pub name: String,
+    // Optional so a bare `{"$ref": ...}` parameter deserializes; the reference
+    // lands in `extensions` and is resolved later.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub description: Option<String>,
-    #[serde(rename = "in")]
-    pub parameter_in: String,
+    #[serde(rename = "in", default, skip_serializing_if = "Option::is_none")]
+    pub parameter_in: Option<String>,
     pub required: Option<bool>,
     pub schema: Option<Schema>,
     #[serde(flatten)]
     pub extensions: HashMap<String, serde_json::Value>,
 }
 
+impl Parameter {
+    /// Parameter name, or `""` when absent (e.g. an unresolved `$ref`).
+    pub fn name(&self) -> &str {
+        self.name.as_deref().unwrap_or_default()
+    }
+
+    /// Parameter location (`query`, `path`, `body`, ...), or `""` when absent.
+    pub fn location(&self) -> &str {
+        self.parameter_in.as_deref().unwrap_or_default()
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Schema {
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "type",
+        default,
+        deserialize_with = "deserialize_optional_type",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub schema_type: Option<String>,
     #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
     pub reference: Option<String>,
     #[serde(flatten)]
     pub extensions: HashMap<String, serde_json::Value>,
+}
+
+/// Deserializes an OpenAPI `type` field as either a string (2.0/3.0) or an array
+/// of strings (3.1, e.g. `["string", "null"]`), normalizing to the first
+/// non-`"null"` type so the rest of the pipeline can keep treating it as scalar.
+fn deserialize_optional_type<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum TypeField {
+        Single(String),
+        Multi(Vec<String>),
+    }
+
+    Ok(match Option::<TypeField>::deserialize(deserializer)? {
+        None => None,
+        Some(TypeField::Single(s)) => Some(s),
+        Some(TypeField::Multi(types)) => types.into_iter().find(|t| t != "null"),
+    })
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -141,9 +187,13 @@ pub struct Components {
     pub request_bodies: Option<HashMap<String, RequestBody>>,
     pub headers: Option<HashMap<String, Header>>,
     #[serde(rename = "securitySchemes")]
-    pub security_schemes: Option<HashMap<String, SecurityScheme>>,
+    pub security_schemes: Option<IndexMap<String, SecurityScheme>>,
     pub links: Option<HashMap<String, Link>>,
     pub callbacks: Option<HashMap<String, Callback>>,
+    // Capture component buckets we don't model explicitly (e.g. `pathItems`) so
+    // `$ref`s into them still resolve against the serialized spec.
+    #[serde(flatten)]
+    pub extensions: HashMap<String, serde_json::Value>,
 }
 
 // Example struct
@@ -160,8 +210,13 @@ pub struct Example {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RequestBody {
     pub description: Option<String>,
+    // Defaulted + `extensions` flatten so a bare `{"$ref": ...}` request body
+    // deserializes instead of failing on the missing `content` field.
+    #[serde(default)]
     pub content: IndexMap<String, MediaType>,
     pub required: Option<bool>,
+    #[serde(flatten)]
+    pub extensions: HashMap<String, serde_json::Value>,
 }
 
 // MediaType struct
@@ -190,6 +245,9 @@ pub struct Encoding {
 pub struct Header {
     pub description: Option<String>,
     pub schema: Option<Schema>,
+    // Same silent-drop shape as path items: capture a `$ref` rather than lose it.
+    #[serde(flatten)]
+    pub extensions: HashMap<String, serde_json::Value>,
 }
 
 // SecurityScheme struct
@@ -229,6 +287,7 @@ pub struct OAuthFlow {
     pub token_url: Option<String>,
     #[serde(rename = "refreshUrl")]
     pub refresh_url: Option<String>,
+    #[serde(default)]
     pub scopes: HashMap<String, String>,
 }
 
@@ -321,5 +380,5 @@ pub struct ApiDocumentation {
     pub services: Vec<Service>,
     pub endpoints: Vec<Endpoint>,
     pub servers: Vec<String>,
-    pub security_schemes: HashMap<String, String>,
+    pub security_schemes: IndexMap<String, String>,
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,9 +7,7 @@ use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use crate::models::{ApiDocumentation, Endpoint, OpenApiSpec, Parameter, Response, Service};
-use crate::utils::{
-    extract_security_schemes, extract_servers, resolve_parameter_ref, resolve_response_ref,
-};
+use crate::utils::{extract_security_schemes, extract_servers, Resolver};
 
 /// Parses an OpenAPI 2.0/3.0 JSON file into the spec-version-agnostic
 /// [`ApiDocumentation`] intermediate representation. On deserialization
@@ -37,7 +35,10 @@ pub fn parse_openapi<P: AsRef<Path>>(path: P) -> Result<ApiDocumentation> {
             let security_schemes = extract_security_schemes(&spec);
             debug!("Extracted {} security schemes", security_schemes.len());
 
-            let endpoints = extract_endpoints(&spec, &services);
+            // Build the reference resolver once (serializes the spec a single time).
+            let resolver = Resolver::new(&spec);
+
+            let endpoints = extract_endpoints(&spec, &services, &resolver);
             debug!("Extracted {} endpoints", endpoints.len());
 
             Ok(ApiDocumentation {
@@ -191,13 +192,35 @@ fn extract_services(spec: &OpenApiSpec) -> Vec<Service> {
 /// Flattens every operation under `paths` into an [`Endpoint`], merging
 /// path-level and operation-level parameters, resolving `$ref`s, and
 /// representing an OpenAPI 3.0 `requestBody` as a synthetic `body` parameter.
-fn extract_endpoints(spec: &OpenApiSpec, services: &[Service]) -> Vec<Endpoint> {
+fn extract_endpoints(
+    spec: &OpenApiSpec,
+    services: &[Service],
+    resolver: &Resolver,
+) -> Vec<Endpoint> {
     let mut endpoints = Vec::new();
 
     // A map of service names to ensure all endpoints are associated with valid services
     let service_map: HashSet<String> = services.iter().map(|s| s.name.clone()).collect();
 
     for (path, path_item) in &spec.paths {
+        // A path item may itself be a `$ref` to a shared definition; resolve it
+        // (otherwise its operations would be silently dropped).
+        let resolved_path_item;
+        let path_item = if path_item.extensions.contains_key("$ref") {
+            match resolver.resolve_path_item(path_item) {
+                Some(item) => {
+                    resolved_path_item = item;
+                    &resolved_path_item
+                }
+                None => {
+                    warn!("Unresolved $ref for path '{}'; skipping", path);
+                    continue;
+                }
+            }
+        } else {
+            path_item
+        };
+
         let operations = [
             ("get", &path_item.get),
             ("post", &path_item.post),
@@ -216,7 +239,7 @@ fn extract_endpoints(spec: &OpenApiSpec, services: &[Service]) -> Vec<Endpoint> 
             .map(|params| {
                 params
                     .iter()
-                    .filter_map(|p| resolve_parameter_ref(spec, p))
+                    .filter_map(|p| resolver.resolve_parameter(p))
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
@@ -256,20 +279,34 @@ fn extract_endpoints(spec: &OpenApiSpec, services: &[Service]) -> Vec<Endpoint> 
 
                 if let Some(op_params) = &operation.parameters {
                     for param in op_params {
-                        if let Some(resolved_param) = resolve_parameter_ref(spec, param) {
+                        if let Some(resolved_param) = resolver.resolve_parameter(param) {
                             parameters.push(resolved_param);
                         }
                     }
                 }
 
                 // Handle request body as a parameter (for OpenAPI 3.0).
+                // The body may be a `$ref`; resolve it first.
                 // Bodies are optional unless the spec says required: true.
                 if let Some(req_body) = &operation.request_body {
+                    let resolved_body;
+                    let req_body = if req_body.extensions.contains_key("$ref") {
+                        match resolver.resolve_request_body(req_body) {
+                            Some(b) => {
+                                resolved_body = b;
+                                &resolved_body
+                            }
+                            None => req_body,
+                        }
+                    } else {
+                        req_body
+                    };
+
                     if let Some((_, media_type)) = req_body.content.first() {
                         parameters.push(Parameter {
-                            name: "requestBody".to_string(),
+                            name: Some("requestBody".to_string()),
                             description: req_body.description.clone(),
-                            parameter_in: "body".to_string(),
+                            parameter_in: Some("body".to_string()),
                             required: Some(req_body.required.unwrap_or(false)),
                             schema: media_type.schema.clone(),
                             extensions: HashMap::new(),
@@ -282,7 +319,8 @@ fn extract_endpoints(spec: &OpenApiSpec, services: &[Service]) -> Vec<Endpoint> 
                     .responses
                     .iter()
                     .map(|(status_code, response)| {
-                        let resolved = resolve_response_ref(spec, response)
+                        let resolved = resolver
+                            .resolve_response(response)
                             .unwrap_or_else(|| response.clone());
                         (status_code.clone(), resolved)
                     })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,72 +1,124 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
-use crate::models::{OpenApiSpec, Parameter, Response};
+use indexmap::IndexMap;
 
-/// Resolves a JSON reference within the OpenAPI specification
-pub fn resolve_ref(spec: &OpenApiSpec, reference: &str) -> Option<serde_json::Value> {
-    if !reference.starts_with("#/") {
-        return None; // We only support internal references for now
-    }
+use crate::models::{OpenApiSpec, Parameter, PathItem, RequestBody, Response};
 
-    // Remove the #/ prefix
-    let path = &reference[2..];
-    let components = path.split('/');
+/// Maximum `$ref` chain / nesting depth the resolver follows before giving up.
+const MAX_REF_DEPTH: usize = 64;
 
-    // Start with the spec as a JSON value
-    let spec_json = serde_json::to_value(spec).ok()?;
-
-    // Navigate the path
-    let mut current = &spec_json;
-    for component in components {
-        // Handle escaped JSON pointer components
-        let unescaped = component.replace("~1", "/").replace("~0", "~");
-
-        if let Some(obj) = current.as_object() {
-            if let Some(value) = obj.get(&unescaped) {
-                current = value;
-            } else {
-                return None; // Component not found
-            }
-        } else if let Some(arr) = current.as_array() {
-            if let Ok(index) = unescaped.parse::<usize>() {
-                if index < arr.len() {
-                    current = &arr[index];
-                } else {
-                    return None; // Index out of bounds
-                }
-            } else {
-                return None; // Invalid array index
-            }
-        } else {
-            return None; // Cannot navigate further
-        }
-    }
-
-    Some(current.clone())
+/// Resolves internal `$ref`s against a spec serialized to JSON exactly once.
+///
+/// The whole spec is serialized into a single `serde_json::Value` at construction
+/// and shared via `Arc`, so repeated resolution is cheap. (Previously every lookup
+/// re-serialized the entire spec — O(spec_size) per `$ref`.)
+#[derive(Debug, Clone)]
+pub struct Resolver {
+    root: Arc<serde_json::Value>,
 }
 
-/// Resolves a parameter reference to a concrete parameter
-pub fn resolve_parameter_ref(spec: &OpenApiSpec, parameter: &Parameter) -> Option<Parameter> {
-    if let Some(extensions) = parameter.extensions.get("$ref") {
-        if let Some(reference) = extensions.as_str() {
-            if let Some(resolved) = resolve_ref(spec, reference) {
-                return serde_json::from_value(resolved).ok();
-            }
+impl Resolver {
+    /// Serializes the spec once. If serialization somehow fails, the resolver is
+    /// inert and every lookup returns `None`.
+    pub fn new(spec: &OpenApiSpec) -> Self {
+        let root = serde_json::to_value(spec).unwrap_or(serde_json::Value::Null);
+        Resolver {
+            root: Arc::new(root),
         }
     }
-    Some(parameter.clone())
-}
 
-/// Resolves a response reference to a concrete response
-pub fn resolve_response_ref(spec: &OpenApiSpec, response: &Response) -> Option<Response> {
-    if let Some(extensions) = response.extensions.get("$ref") {
-        if let Some(reference) = extensions.as_str() {
-            if let Some(resolved) = resolve_ref(spec, reference) {
-                return serde_json::from_value(resolved).ok();
+    /// Resolves a `#/...` JSON pointer to its target, following `$ref` chains and
+    /// guarding against cycles and runaway depth.
+    pub fn resolve(&self, reference: &str) -> Option<serde_json::Value> {
+        let mut seen = HashSet::new();
+        self.resolve_inner(reference, &mut seen, 0)
+    }
+
+    fn resolve_inner(
+        &self,
+        reference: &str,
+        seen: &mut HashSet<String>,
+        depth: usize,
+    ) -> Option<serde_json::Value> {
+        // Break cycles and bound depth.
+        if depth >= MAX_REF_DEPTH || !seen.insert(reference.to_string()) {
+            return None;
+        }
+
+        let value = self.lookup(reference)?;
+
+        // Follow ref-to-ref chains (e.g. a component that is itself a `$ref`).
+        if let Some(next) = value
+            .as_object()
+            .and_then(|o| o.get("$ref"))
+            .and_then(|r| r.as_str())
+        {
+            return self.resolve_inner(next, seen, depth + 1);
+        }
+
+        Some(value)
+    }
+
+    /// One JSON-pointer navigation step (no chain following).
+    fn lookup(&self, reference: &str) -> Option<serde_json::Value> {
+        let path = reference.strip_prefix("#/")?;
+        let mut current = self.root.as_ref();
+        for component in path.split('/') {
+            // Handle escaped JSON pointer components.
+            let unescaped = component.replace("~1", "/").replace("~0", "~");
+            if let Some(obj) = current.as_object() {
+                current = obj.get(&unescaped)?;
+            } else if let Some(arr) = current.as_array() {
+                let index = unescaped.parse::<usize>().ok()?;
+                current = arr.get(index)?;
+            } else {
+                return None;
             }
         }
+        Some(current.clone())
     }
-    Some(response.clone())
+
+    /// Resolves a parameter that may be a `$ref`; returns it unchanged when inline.
+    pub fn resolve_parameter(&self, parameter: &Parameter) -> Option<Parameter> {
+        match self.ref_target(&parameter.extensions) {
+            Some(resolved) => serde_json::from_value(resolved).ok(),
+            None => Some(parameter.clone()),
+        }
+    }
+
+    /// Resolves a response that may be a `$ref`.
+    pub fn resolve_response(&self, response: &Response) -> Option<Response> {
+        match self.ref_target(&response.extensions) {
+            Some(resolved) => serde_json::from_value(resolved).ok(),
+            None => Some(response.clone()),
+        }
+    }
+
+    /// Resolves a request body that may be a `$ref`.
+    pub fn resolve_request_body(&self, body: &RequestBody) -> Option<RequestBody> {
+        match self.ref_target(&body.extensions) {
+            Some(resolved) => serde_json::from_value(resolved).ok(),
+            None => Some(body.clone()),
+        }
+    }
+
+    /// Resolves a path item that may be a `$ref`.
+    pub fn resolve_path_item(&self, item: &PathItem) -> Option<PathItem> {
+        match self.ref_target(&item.extensions) {
+            Some(resolved) => serde_json::from_value(resolved).ok(),
+            None => Some(item.clone()),
+        }
+    }
+
+    /// If an `extensions` map carries a `$ref`, resolve its target.
+    fn ref_target(
+        &self,
+        extensions: &HashMap<String, serde_json::Value>,
+    ) -> Option<serde_json::Value> {
+        let reference = extensions.get("$ref")?.as_str()?;
+        self.resolve(reference)
+    }
 }
 
 /// Extracts servers from the OpenAPI spec
@@ -110,9 +162,9 @@ pub fn extract_servers(spec: &OpenApiSpec) -> Vec<String> {
     servers
 }
 
-/// Extracts security schemes from the OpenAPI spec
-pub fn extract_security_schemes(spec: &OpenApiSpec) -> HashMap<String, String> {
-    let mut schemes = HashMap::new();
+/// Extracts security schemes from the OpenAPI spec, preserving declaration order.
+pub fn extract_security_schemes(spec: &OpenApiSpec) -> IndexMap<String, String> {
+    let mut schemes = IndexMap::new();
 
     // OpenAPI 3.0+: components.securitySchemes
     if let Some(components) = &spec.components {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -5,6 +5,13 @@ use std::io::Write;
 const OAS3: &str = "tests/fixtures/petstore_oas3.json";
 const OAS2: &str = "tests/fixtures/petstore_oas2.json";
 
+// Fixtures for ref-aware, tolerant parsing (issues #48, #50, #51, #56, #49).
+const REF_PARAM_BODY: &str = "tests/fixtures/ref_param_and_body.json";
+const REF_PATH_ITEM: &str = "tests/fixtures/ref_path_item.json";
+const TYPE_ARRAY: &str = "tests/fixtures/type_array_nullable.json";
+const MISSING_RESPONSES: &str = "tests/fixtures/missing_responses.json";
+const MULTI_AUTH: &str = "tests/fixtures/multi_auth.json";
+
 fn vimanam() -> Command {
     Command::cargo_bin("vimanam").unwrap()
 }
@@ -181,6 +188,105 @@ fn json_without_openapi_fields_fails() {
     write!(file, "{{\"hello\": \"world\"}}").unwrap();
 
     vimanam().arg(file.path()).assert().failure();
+}
+
+// #48: a parameter declared as a component `$ref` is resolved instead of
+// failing the whole parse (regression — bare `$ref` params used to crash).
+#[test]
+fn ref_parameter_is_resolved() {
+    vimanam()
+        .arg(REF_PARAM_BODY)
+        .args(["--detail", "standard"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "| `limit` | query | No | Max results |",
+        ));
+}
+
+// #48: a requestBody declared as a component `$ref` is resolved.
+#[test]
+fn ref_request_body_is_resolved() {
+    vimanam()
+        .arg(REF_PARAM_BODY)
+        .args(["--detail", "standard"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "| `requestBody` | body | No | Item payload |",
+        ));
+}
+
+// #50: a path item declared as a `$ref` yields its operations instead of being
+// silently dropped.
+#[test]
+fn path_item_ref_yields_operation() {
+    vimanam()
+        .arg(REF_PATH_ITEM)
+        .args(["--detail", "basic"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Things_ListThings"))
+        .stdout(predicate::str::contains("**Operation:** GET /things"));
+}
+
+// #51: OpenAPI 3.1 `type` arrays (e.g. ["string","null"]) parse instead of
+// failing on "invalid type: sequence".
+#[test]
+fn type_array_parameter_parses() {
+    vimanam()
+        .arg(TYPE_ARRAY)
+        .args(["--detail", "standard"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "| `q` | query | No | Search term |",
+        ));
+}
+
+// #56: an operation missing its `responses` block no longer fails the entire
+// document; both operations are still rendered.
+#[test]
+fn operation_missing_responses_still_parses() {
+    vimanam()
+        .arg(MISSING_RESPONSES)
+        .args(["--detail", "basic"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("A_NoResponses"))
+        .stdout(predicate::str::contains("B_HasResponses"));
+}
+
+// #49: all security schemes are listed.
+#[test]
+fn multi_auth_lists_all_schemes() {
+    vimanam()
+        .arg(MULTI_AUTH)
+        .arg("--include-auth")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("alphaAuth"))
+        .stdout(predicate::str::contains("middleAuth"))
+        .stdout(predicate::str::contains("zebraAuth"));
+}
+
+// #49: with multiple security schemes, the Authentication section must come out
+// in a stable order across runs (previously backed by a HashMap).
+#[test]
+fn multi_auth_order_is_deterministic() {
+    let run = || {
+        vimanam()
+            .arg(MULTI_AUTH)
+            .args(["--include-auth", "--detail", "standard"])
+            .output()
+            .unwrap()
+            .stdout
+    };
+
+    let first = run();
+    for _ in 0..4 {
+        assert_eq!(first, run(), "auth section order differed between runs");
+    }
 }
 
 // Output must be byte-identical across runs, even with sorting disabled.

--- a/tests/fixtures/missing_responses.json
+++ b/tests/fixtures/missing_responses.json
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Missing Responses API", "version": "1.0" },
+  "paths": {
+    "/a": {
+      "get": {
+        "tags": ["A"],
+        "operationId": "A_NoResponses",
+        "summary": "Operation with no responses block"
+      }
+    },
+    "/b": {
+      "get": {
+        "tags": ["B"],
+        "operationId": "B_HasResponses",
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  }
+}

--- a/tests/fixtures/multi_auth.json
+++ b/tests/fixtures/multi_auth.json
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Multi Auth API", "version": "1.0" },
+  "paths": {
+    "/x": {
+      "get": {
+        "tags": ["X"],
+        "operationId": "X_Get",
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "zebraAuth": { "type": "apiKey", "name": "X-Zebra", "in": "header", "description": "Zebra" },
+      "alphaAuth": { "type": "http", "scheme": "bearer", "description": "Alpha" },
+      "middleAuth": { "type": "apiKey", "name": "X-Middle", "in": "header", "description": "Middle" }
+    }
+  }
+}

--- a/tests/fixtures/ref_param_and_body.json
+++ b/tests/fixtures/ref_param_and_body.json
@@ -1,0 +1,37 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Ref Param API", "version": "1.0" },
+  "paths": {
+    "/items": {
+      "get": {
+        "tags": ["Items"],
+        "operationId": "Items_ListItems",
+        "parameters": [{ "$ref": "#/components/parameters/LimitParam" }],
+        "responses": { "200": { "description": "ok" } }
+      },
+      "post": {
+        "tags": ["Items"],
+        "operationId": "Items_CreateItem",
+        "requestBody": { "$ref": "#/components/requestBodies/ItemBody" },
+        "responses": { "201": { "description": "created" } }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "LimitParam": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "Max results",
+        "schema": { "type": "integer" }
+      }
+    },
+    "requestBodies": {
+      "ItemBody": {
+        "description": "Item payload",
+        "content": { "application/json": { "schema": { "type": "object" } } }
+      }
+    }
+  }
+}

--- a/tests/fixtures/ref_path_item.json
+++ b/tests/fixtures/ref_path_item.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Ref Path API", "version": "1.0" },
+  "paths": {
+    "/things": { "$ref": "#/components/pathItems/Shared" }
+  },
+  "components": {
+    "pathItems": {
+      "Shared": {
+        "get": {
+          "tags": ["Things"],
+          "operationId": "Things_ListThings",
+          "summary": "List things",
+          "responses": { "200": { "description": "ok" } }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/type_array_nullable.json
+++ b/tests/fixtures/type_array_nullable.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Nullable Type API", "version": "1.0" },
+  "paths": {
+    "/search": {
+      "get": {
+        "tags": ["Search"],
+        "operationId": "Search_Query",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Search term",
+            "schema": { "type": ["string", "null"] }
+          }
+        ],
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes a cluster of parse-layer bugs that share one root cause — an over-strict serde model — plus a determinism bug. Found via a full source audit and testing against real-world specs.

Closes #48, #50, #51, #56, #49.

## What changed

| Issue | Fix |
|------|-----|
| #48 | `$ref` in parameter/requestBody position no longer fails the whole parse. `Parameter.name`/`in` are now optional and `RequestBody` gains a flatten extensions map, so a bare `{"$ref": ...}` deserializes and is resolved. (The resolver code for this was previously **dead** — the spec crashed on deserialize first.) |
| #50 | A path item declared as a `$ref` now yields its operations instead of being silently dropped; warns if it can't be resolved. |
| #51 | OpenAPI 3.1 `type` arrays (e.g. `["string","null"]`) parse, normalizing to the first non-null type. `Schema` stays shallow. |
| #56 | An operation missing `responses` (and other non-critical fields) no longer aborts the whole document. |
| #49 | Security schemes use `IndexMap` end to end → deterministic Authentication section with 2+ schemes. Enables `serde_json` `preserve_order` for spec-order fidelity everywhere. |

## Resolver (mandatory coupled change)

Reference resolution is consolidated into a `Resolver` that serializes the spec **once** (was `O(spec_size)` per `$ref`) and guards against ref cycles and runaway depth. This is required because fixing #48 activates that previously-dead resolution path. `Components` gains a flatten map so component buckets we don't model explicitly (e.g. `pathItems`) still resolve.

The resolver is intentionally **not** carried into the IR in this PR — that's prep for inline-refs (#46), which is deferred. See #46 for the follow-up.

## Tests

- 5 new synthetic fixtures + 7 tests, one per fixed behavior, including a multi-scheme determinism test (`multi_auth_order_is_deterministic`).
- All 22 integration tests pass; `cargo fmt`/`clippy` clean.
- Smoke-tested locally against large real-world OAS2 and OAS3 specs: all parse (rc=0) and are byte-identical across runs.

## Notes / out of scope

- The fabricated default server URL (#52) and other lower-severity items are intentionally left for separate PRs.
- `paths` deliberately remains required so the "Missing 'paths'" targeted error message is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for OpenAPI documents with `$ref`-based path items, parameters, request bodies, and responses.
  * Added support for OpenAPI 3.1 nullable type arrays and documents with missing response blocks.
  * Authentication schemes now appear in a consistent, deterministic order.

* **Bug Fixes**
  * Reduced parsing failures for partially specified or reference-heavy specs.
  * Preserved more document order in generated output for stable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->