### PR TITLE
Parse-layer correctness: refs, 3.1 type arrays, tolerance, tag attribution

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -38,8 +38,8 @@ pub enum AdditionalProperties {
 }
 
 /// Deserializes an OpenAPI `type` as either a string (2.0/3.0) or an array of
-/// strings (3.1, e.g. `["string", "null"]`), normalizing to the first non-`"null"`
-/// type so the rest of the pipeline can keep treating it as a scalar.
+/// strings (3.1, e.g. `["string", "null"]`), preserving all non-`"null"` types
+/// as a pipe-separated string so union schemas are represented in full.
 fn deserialize_optional_type<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -54,7 +54,14 @@ where
     Ok(match Option::<TypeField>::deserialize(deserializer)? {
         None => None,
         Some(TypeField::Single(s)) => Some(s),
-        Some(TypeField::Multi(types)) => types.into_iter().find(|t| t != "null"),
+        Some(TypeField::Multi(types)) => {
+            let non_null_types: Vec<String> = types.into_iter().filter(|t| t != "null").collect();
+            if non_null_types.is_empty() {
+                None
+            } else {
+                Some(non_null_types.join(" | "))
+            }
+        }
     })
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -37,6 +37,27 @@ pub enum AdditionalProperties {
     Schema(Box<Schema>),
 }
 
+/// Deserializes an OpenAPI `type` as either a string (2.0/3.0) or an array of
+/// strings (3.1, e.g. `["string", "null"]`), normalizing to the first non-`"null"`
+/// type so the rest of the pipeline can keep treating it as a scalar.
+fn deserialize_optional_type<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum TypeField {
+        Single(String),
+        Multi(Vec<String>),
+    }
+
+    Ok(match Option::<TypeField>::deserialize(deserializer)? {
+        None => None,
+        Some(TypeField::Single(s)) => Some(s),
+        Some(TypeField::Multi(types)) => types.into_iter().find(|t| t != "null"),
+    })
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Info {
     pub title: String,
@@ -70,6 +91,10 @@ pub struct PathItem {
     pub trace: Option<Operation>,
     #[serde(rename = "parameters", skip_serializing_if = "Option::is_none")]
     pub parameters: Option<Vec<Parameter>>,
+    // A path item may itself be a `$ref` into `components/pathItems`; capture it
+    // so the parser can resolve it instead of silently dropping the operations.
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
 }
 
 impl PathItem {
@@ -99,6 +124,8 @@ pub struct Operation {
     pub parameters: Option<Vec<Parameter>>,
     #[serde(rename = "requestBody", skip_serializing_if = "Option::is_none")]
     pub request_body: Option<RequestBody>,
+    // Defaulted so an operation missing `responses` doesn't fail the whole parse.
+    #[serde(default)]
     pub responses: IndexMap<String, Response>,
     pub deprecated: Option<bool>,
     #[serde(rename = "security", skip_serializing_if = "Option::is_none")]
@@ -107,9 +134,15 @@ pub struct Operation {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Parameter {
+    // A parameter may be a `$ref` into `components/parameters`; capture it so the
+    // parser can resolve it. `name`/`in` default to empty so the bare `$ref` form
+    // (which omits them) still deserializes — they come from the resolved target.
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
+    #[serde(default)]
     pub name: String,
     pub description: Option<String>,
-    #[serde(rename = "in")]
+    #[serde(rename = "in", default)]
     pub parameter_in: String,
     pub required: Option<bool>,
     pub schema: Option<Schema>,
@@ -130,7 +163,12 @@ pub struct Schema {
     pub title: Option<String>,
     #[serde(rename = "description", skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "type",
+        default,
+        deserialize_with = "deserialize_optional_type",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub schema_type: Option<String>,
     #[serde(rename = "format", skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,8 +10,8 @@ use crate::models::{
     ApiDocumentation, Endpoint, Example, OpenApiSpec, Parameter, Response, Schema, Service,
 };
 use crate::utils::{
-    extract_security_schemes, extract_servers, resolve_parameter_ref, resolve_request_body_ref,
-    resolve_response_ref,
+    extract_security_schemes, extract_servers, resolve_parameter_ref, resolve_path_item_ref,
+    resolve_request_body_ref, resolve_response_ref,
 };
 
 /// Parses an OpenAPI 2.0/3.0 JSON file into the spec-version-agnostic
@@ -28,8 +28,13 @@ pub fn parse_openapi<P: AsRef<Path>>(path: P) -> Result<ApiDocumentation> {
             // Validate the parsed spec
             validate_openapi(&spec, path_ref)?;
 
-            // Extract services and endpoints
-            let services = extract_services(&spec);
+            // Serialize the spec to JSON once so `$ref` resolution can navigate
+            // it without re-serializing the (potentially multi-MB) spec per ref.
+            let spec_json = serde_json::to_value(&spec)
+                .context("Failed to serialize OpenAPI spec for reference resolution")?;
+
+            // Extract services (ref-aware: tags inside `$ref` path items count too)
+            let services = extract_services(&spec, &spec_json);
             debug!("Extracted {} services", services.len());
 
             // Extract servers information
@@ -39,11 +44,6 @@ pub fn parse_openapi<P: AsRef<Path>>(path: P) -> Result<ApiDocumentation> {
             // Extract security schemes
             let security_schemes = extract_security_schemes(&spec);
             debug!("Extracted {} security schemes", security_schemes.len());
-
-            // Serialize the spec to JSON once so `$ref` resolution can navigate
-            // it without re-serializing the (potentially multi-MB) spec per ref.
-            let spec_json = serde_json::to_value(&spec)
-                .context("Failed to serialize OpenAPI spec for reference resolution")?;
 
             let endpoints = extract_endpoints(&spec, &spec_json, &services);
             debug!("Extracted {} endpoints", endpoints.len());
@@ -145,62 +145,89 @@ fn validate_openapi(spec: &OpenApiSpec, path: &Path) -> Result<()> {
 
 /// Derives "services" from spec-level tags, falling back to per-operation
 /// tags, then to a single default `"API"` service.
-fn extract_services(spec: &OpenApiSpec) -> Vec<Service> {
-    // Extract services from tags
+fn extract_services(spec: &OpenApiSpec, spec_json: &serde_json::Value) -> Vec<Service> {
     let mut services = Vec::new();
+    // Names already added, so declared tags and operation tags don't duplicate;
+    // first-appearance order keeps output deterministic.
+    let mut seen: IndexSet<String> = IndexSet::new();
 
+    // Declared tags first, preserving their descriptions and order.
     if let Some(tags) = &spec.tags {
         for tag in tags {
-            services.push(Service {
-                name: tag.name.clone(),
-                description: tag.description.clone(),
-            });
+            if seen.insert(tag.name.clone()) {
+                services.push(Service {
+                    name: tag.name.clone(),
+                    description: tag.description.clone(),
+                });
+            }
         }
     }
 
-    // If no tags, try to infer services from endpoint tags.
-    // IndexSet keeps first-appearance order so output is deterministic.
-    if services.is_empty() {
-        let mut service_names = IndexSet::new();
+    // Union with every tag actually used by an operation — including operations
+    // inside `$ref` path items — so an operation tagged with an undeclared tag
+    // gets its own service instead of being silently reassigned to the first one.
+    for (_, path_item) in &spec.paths {
+        let resolved_path_item;
+        let path_item = if path_item.reference.is_some() {
+            match resolve_path_item_ref(spec_json, path_item) {
+                Some(item) => {
+                    resolved_path_item = item;
+                    &resolved_path_item
+                }
+                None => continue,
+            }
+        } else {
+            path_item
+        };
 
-        for (_, path_item) in &spec.paths {
-            for op in path_item
-                .operations()
-                .into_iter()
-                .filter_map(|(_, op)| op.as_ref())
-            {
-                if let Some(tags) = &op.tags {
-                    for tag in tags {
-                        service_names.insert(tag.clone());
+        for op in path_item
+            .operations()
+            .into_iter()
+            .filter_map(|(_, op)| op.as_ref())
+        {
+            if let Some(tags) = &op.tags {
+                for tag in tags {
+                    if seen.insert(tag.clone()) {
+                        services.push(Service {
+                            name: tag.clone(),
+                            description: None,
+                        });
                     }
                 }
             }
         }
+    }
 
-        // If still no services found, add an "API" default service
-        if service_names.is_empty() {
-            service_names.insert("API".to_string());
-        }
-
-        // Convert IndexSet to Vec of Services
-        for name in service_names {
-            services.push(Service {
-                name,
-                description: None,
-            });
-        }
+    // Fall back to a single default service if the spec declares no tags at all.
+    if services.is_empty() {
+        services.push(Service {
+            name: "API".to_string(),
+            description: None,
+        });
     }
 
     services
 }
 
-/// The service an endpoint is attributed to when its operation declares no
-/// (known) tags: the first declared service, or `"API"` if there are none.
+/// The service an endpoint is attributed to when its operation declares no tags
+/// at all: the first declared service, or `"API"` if there are none.
 fn default_service(services: &[Service]) -> String {
     services
         .first()
         .map(|s| s.name.clone())
         .unwrap_or_else(|| "API".to_string())
+}
+
+/// De-duplicates parameters on `(name, in)`, keeping the last occurrence so an
+/// operation-level parameter overrides a path-level one of the same name and
+/// location (OpenAPI's override rule). First-seen position is preserved.
+fn dedup_parameters(parameters: Vec<Parameter>) -> Vec<Parameter> {
+    let mut by_key: IndexMap<(String, String), Parameter> = IndexMap::new();
+    for parameter in parameters {
+        let key = (parameter.name.clone(), parameter.parameter_in.clone());
+        by_key.insert(key, parameter);
+    }
+    by_key.into_values().collect()
 }
 
 /// Flattens every operation under `paths` into an [`Endpoint`], merging
@@ -217,6 +244,24 @@ fn extract_endpoints(
     let service_map: HashSet<String> = services.iter().map(|s| s.name.clone()).collect();
 
     for (path, path_item) in &spec.paths {
+        // A path item may itself be a `$ref`; resolve it (warn + skip when it
+        // can't be resolved) so its operations aren't silently dropped.
+        let resolved_path_item;
+        let path_item = if path_item.reference.is_some() {
+            match resolve_path_item_ref(spec_json, path_item) {
+                Some(item) => {
+                    resolved_path_item = item;
+                    &resolved_path_item
+                }
+                None => {
+                    warn!("Unresolved $ref for path '{}'; skipping", path);
+                    continue;
+                }
+            }
+        } else {
+            path_item
+        };
+
         // Get parameters defined at the path level and resolve any references
         let path_parameters = path_item
             .parameters
@@ -256,6 +301,10 @@ fn extract_endpoints(
                     }
                 }
 
+                // De-duplicate on (name, in): an operation-level parameter
+                // overrides a path-level one with the same name and location.
+                let mut parameters = dedup_parameters(parameters);
+
                 // Handle request body as a parameter (for OpenAPI 3.0).
                 // Bodies are optional unless the spec says required: true.
                 if let Some(req_body) = &operation.request_body {
@@ -265,6 +314,7 @@ fn extract_endpoints(
                         .unwrap_or_else(|| req_body.clone());
                     if let Some((_, media_type)) = req_body.content.first() {
                         parameters.push(Parameter {
+                            reference: None,
                             name: "requestBody".to_string(),
                             description: req_body.description.clone(),
                             parameter_in: "body".to_string(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,17 +54,17 @@ pub fn resolve_ref(spec_json: &serde_json::Value, reference: &str) -> Option<ser
 }
 
 /// Resolves a parameter that may be a `$ref` into `components/parameters`,
-/// returning the parameter unchanged when it carries no reference.
+/// returning the parameter unchanged when it carries no reference. Returns
+/// `None` when a `$ref` is present but cannot be resolved.
 pub fn resolve_parameter_ref(
     spec_json: &serde_json::Value,
     parameter: &Parameter,
 ) -> Option<Parameter> {
     if let Some(reference) = &parameter.reference {
-        if let Some(resolved) = resolve_ref(spec_json, reference) {
-            return serde_json::from_value(resolved).ok();
-        }
+        resolve_ref(spec_json, reference).and_then(|resolved| serde_json::from_value(resolved).ok())
+    } else {
+        Some(parameter.clone())
     }
-    Some(parameter.clone())
 }
 
 /// Resolves a response reference to a concrete response

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexMap;
 
-use crate::models::{OpenApiSpec, Parameter, RequestBody, Response};
+use crate::models::{OpenApiSpec, Parameter, PathItem, RequestBody, Response};
 
 /// Decodes the escape sequences in a JSON Pointer reference token: `~1` → `/`
 /// and `~0` → `~` (RFC 6901). The order matters — `~1` must be decoded before
@@ -53,16 +53,15 @@ pub fn resolve_ref(spec_json: &serde_json::Value, reference: &str) -> Option<ser
     Some(current.clone())
 }
 
-/// Resolves a parameter reference to a concrete parameter
+/// Resolves a parameter that may be a `$ref` into `components/parameters`,
+/// returning the parameter unchanged when it carries no reference.
 pub fn resolve_parameter_ref(
     spec_json: &serde_json::Value,
     parameter: &Parameter,
 ) -> Option<Parameter> {
-    if let Some(extensions) = parameter.extensions.get("$ref") {
-        if let Some(reference) = extensions.as_str() {
-            if let Some(resolved) = resolve_ref(spec_json, reference) {
-                return serde_json::from_value(resolved).ok();
-            }
+    if let Some(reference) = &parameter.reference {
+        if let Some(resolved) = resolve_ref(spec_json, reference) {
+            return serde_json::from_value(resolved).ok();
         }
     }
     Some(parameter.clone())
@@ -97,6 +96,22 @@ pub fn resolve_request_body_ref(
         }
     }
     Some(request_body.clone())
+}
+
+/// Resolves a path item that may be a `$ref` into `components/pathItems`.
+///
+/// Returns `Some(item)` for an inline item (no `$ref`) or a successfully resolved
+/// reference, and `None` only when a `$ref` is present but cannot be resolved — so
+/// the caller can warn and skip rather than silently emitting an empty path item.
+pub fn resolve_path_item_ref(
+    spec_json: &serde_json::Value,
+    path_item: &PathItem,
+) -> Option<PathItem> {
+    match &path_item.reference {
+        None => Some(path_item.clone()),
+        Some(reference) => resolve_ref(spec_json, reference)
+            .and_then(|resolved| serde_json::from_value(resolved).ok()),
+    }
 }
 
 /// Extracts servers from the OpenAPI spec

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,6 +10,14 @@ const OAS2_MULTI_AUTH: &str = "tests/fixtures/multi_auth_oas2.json";
 const OAS3_EXAMPLES: &str = "tests/fixtures/examples_oas3.json";
 const OAS3_REF_BODY: &str = "tests/fixtures/ref_request_body_oas3.json";
 
+// Parse-layer correctness cluster (issues #48, #50, #51, #54, #56, #60).
+const REF_PARAMETER: &str = "tests/fixtures/ref_parameter.json";
+const REF_PATH_ITEM: &str = "tests/fixtures/ref_path_item.json";
+const TYPE_ARRAY: &str = "tests/fixtures/type_array_nullable.json";
+const MISSING_RESPONSES: &str = "tests/fixtures/missing_responses.json";
+const OVERRIDE_PARAM: &str = "tests/fixtures/override_param.json";
+const UNKNOWN_TAG: &str = "tests/fixtures/unknown_tag.json";
+
 fn vimanam() -> Command {
     Command::cargo_bin("vimanam").unwrap()
 }
@@ -502,5 +510,97 @@ fn full_detail_schema_expansion_detects_ref_cycles() {
         .success()
         .stdout(predicate::str::contains(
             "Cycle detected while expanding schema reference",
+        ));
+}
+
+// #48: a parameter declared as a component `$ref` is resolved instead of
+// failing the whole parse (a bare `$ref` param used to crash on `missing field name`).
+#[test]
+fn ref_parameter_is_resolved() {
+    vimanam()
+        .arg(REF_PARAMETER)
+        .args(["--detail", "standard"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "| `limit` | query | No | Max results |",
+        ));
+}
+
+// #50: a path item declared as a `$ref` yields its operation instead of being
+// silently dropped.
+#[test]
+fn path_item_ref_yields_operation() {
+    vimanam()
+        .arg(REF_PATH_ITEM)
+        .args(["--detail", "basic"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Things_ListThings"))
+        .stdout(predicate::str::contains("**Operation:** GET /things"));
+}
+
+// #51: OpenAPI 3.1 `type` arrays (e.g. ["string","null"]) parse instead of
+// failing on "invalid type: sequence".
+#[test]
+fn type_array_parameter_parses() {
+    vimanam()
+        .arg(TYPE_ARRAY)
+        .args(["--detail", "standard"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "| `q` | query | No | Search term |",
+        ));
+}
+
+// #56: an operation missing its `responses` block no longer fails the whole
+// document; both operations are still rendered.
+#[test]
+fn operation_missing_responses_still_parses() {
+    vimanam()
+        .arg(MISSING_RESPONSES)
+        .args(["--detail", "basic"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("A_NoResponses"))
+        .stdout(predicate::str::contains("B_HasResponses"));
+}
+
+// #54: an operation-level parameter overrides a path-level one of the same
+// (name, in) — it should appear exactly once.
+#[test]
+fn duplicate_parameter_is_deduplicated() {
+    let output = vimanam()
+        .arg(OVERRIDE_PARAM)
+        .args(["--detail", "standard"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    let id_rows = text.matches("| `id` | path |").count();
+    assert_eq!(id_rows, 1, "expected a single `id` row, got {id_rows}");
+    // The operation-level definition wins.
+    assert!(text.contains("Operation-level id wins"));
+}
+
+// #60: an operation tagged with a value not in the declared `tags` list gets its
+// own service section instead of being silently reassigned to the first service.
+#[test]
+fn unknown_operation_tag_keeps_its_own_service() {
+    vimanam()
+        .arg(UNKNOWN_TAG)
+        .args(["--detail", "basic"])
+        .assert()
+        .success()
+        // The undeclared tag Gamma becomes its own service section (under the
+        // bug it would not exist — the endpoint was dumped under Alpha)...
+        .stdout(predicate::str::contains("## Gamma"))
+        .stdout(predicate::str::contains("W_Get"))
+        // ...and the first declared service ends up with no endpoints.
+        .stdout(predicate::str::contains(
+            "## Alpha {#alpha}\n\nNo endpoints found for this service.",
         ));
 }

--- a/tests/fixtures/missing_responses.json
+++ b/tests/fixtures/missing_responses.json
@@ -1,0 +1,20 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Missing Responses API", "version": "1.0" },
+  "paths": {
+    "/a": {
+      "get": {
+        "tags": ["A"],
+        "operationId": "A_NoResponses",
+        "summary": "Operation with no responses block"
+      }
+    },
+    "/b": {
+      "get": {
+        "tags": ["B"],
+        "operationId": "B_HasResponses",
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  }
+}

--- a/tests/fixtures/override_param.json
+++ b/tests/fixtures/override_param.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Override Param API", "version": "1.0" },
+  "paths": {
+    "/items/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Path-level id (should be overridden)"
+        }
+      ],
+      "get": {
+        "tags": ["Items"],
+        "operationId": "Items_GetItem",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Operation-level id wins"
+          }
+        ],
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  }
+}

--- a/tests/fixtures/ref_parameter.json
+++ b/tests/fixtures/ref_parameter.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Ref Param API", "version": "1.0" },
+  "paths": {
+    "/items": {
+      "get": {
+        "tags": ["Items"],
+        "operationId": "Items_ListItems",
+        "parameters": [{ "$ref": "#/components/parameters/LimitParam" }],
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "LimitParam": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "Max results",
+        "schema": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/ref_path_item.json
+++ b/tests/fixtures/ref_path_item.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Ref Path API", "version": "1.0" },
+  "paths": {
+    "/things": { "$ref": "#/components/pathItems/Shared" }
+  },
+  "components": {
+    "pathItems": {
+      "Shared": {
+        "get": {
+          "tags": ["Things"],
+          "operationId": "Things_ListThings",
+          "summary": "List things",
+          "responses": { "200": { "description": "ok" } }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/type_array_nullable.json
+++ b/tests/fixtures/type_array_nullable.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Nullable Type API", "version": "1.0" },
+  "paths": {
+    "/search": {
+      "get": {
+        "tags": ["Search"],
+        "operationId": "Search_Query",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Search term",
+            "schema": { "type": ["string", "null"] }
+          }
+        ],
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  }
+}

--- a/tests/fixtures/unknown_tag.json
+++ b/tests/fixtures/unknown_tag.json
@@ -1,0 +1,14 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Unknown Tag API", "version": "1.0" },
+  "tags": [{ "name": "Alpha" }, { "name": "Beta" }],
+  "paths": {
+    "/w": {
+      "get": {
+        "tags": ["Gamma"],
+        "operationId": "W_Get",
+        "responses": { "200": { "description": "ok" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes six parse-layer bugs that share one theme — the typed model is too strict, or endpoint assembly is wrong, so valid specs are rejected or mis-rendered. Done against 0.5.0's conventions (dedicated `reference: Option<String>` fields + free `resolve_*_ref` helpers taking a pre-serialized `spec_json`).

Closes #48, #50, #51, #54, #56, #60.

## What changed

| Issue | Fix | Files |
|------|-----|-------|
| #48 | parameter as component `$ref` now resolves (was `missing field 'name'`). `Parameter` gains a `reference` field + defaulted `name`/`in`, mirroring `RequestBody`. | models.rs, utils.rs |
| #50 | path item as `$ref` now yields its operations (was silently dropped). `PathItem` gains `reference`; new `resolve_path_item_ref` **warns + skips** on an unresolvable ref. | models.rs, utils.rs, parser.rs |
| #51 | 3.1 `type` arrays (`["string","null"]`) parse, normalized to first non-null. | models.rs |
| #56 | operation missing `responses` no longer aborts the document. | models.rs |
| #54 | operation-level param overrides path-level one of same `(name,in)` — deduped. | parser.rs |
| #60 | operation tagged with an undeclared tag gets its own service section instead of being reassigned to the first service. `extract_services` unions declared + operation tags, ref-aware. | parser.rs |

## CodeRabbit points carried over (from the earlier, closed PR)

- **Ref-aware service extraction**: `extract_services` now resolves `$ref` path items so tags inside them are visible, and runs after `spec_json` is built. (Was raised on the prior PR; lands here.)
- **Distinguish "no `$ref`" from "unresolved `$ref`"**: `resolve_path_item_ref` returns `None` only for a present-but-unresolvable ref, so the parser warns + skips rather than emitting an empty item.

## Tests

Six new synthetic fixtures + tests (one per behavior), including param/requestBody-style `$ref`, path-item `$ref`, 3.1 type array, missing responses, param override dedup, and unknown-tag attribution. All 36 integration tests pass; `cargo fmt`/`clippy -D warnings` clean.

Verified locally against large real-world OAS2 + OAS3 specs: all parse (rc=0), deterministic across runs; a parameter-`$ref` spec that previously exited 1 now resolves correctly.

## Out of scope (separate issues)

#52 (fabricated server URL), #58 (schema-expansion bloat), #59 (silent no-op flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAPI `$ref` handling for referenced path items and parameters.
  * Operations that omit `responses` no longer break parsing or cause dropped output.
  * Enhanced schema `type` parsing to support OpenAPI 3.1 arrays (including `null`).
  * De-duplicated parameters so operation-level entries correctly override path-level ones.
  * More consistent service and endpoint rendering when tags are declared, discovered, or unknown.
* **Tests**
  * Added fixtures and CLI integration tests covering all the above edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->