### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-24
+
+### Fixed
+
+- Parameters given as a `$ref` (`#/components/parameters/...`) are now resolved
+  during parsing; previously such specs failed to parse entirely because the
+  bare `$ref` parameter carries no `name`/`in` (#48)
+- Path items given as a `$ref` (`#/components/pathItems/...`) now contribute
+  their operations instead of being silently dropped; an unresolvable path-item
+  reference is logged and skipped (#50)
+- OpenAPI 3.1 `type` arrays (e.g. `["string", "null"]`) now parse instead of
+  failing; multiple non-null members render as a pipe-separated union such as
+  `string | integer` (#51)
+- Operations missing a `responses` object no longer abort the entire parse (#56)
+- An operation-level parameter now overrides a path-level one of the same
+  `(name, in)` instead of both rendering as duplicate rows (#54)
+- Operations tagged with a value not in the declared `tags` list now get their
+  own service section instead of being silently reassigned to the first service;
+  service extraction is also `$ref`-aware so tags inside referenced path items
+  are seen (#60)
+
 ### Changed
 
 - Release artifacts are now compressed archives instead of bare binaries:
@@ -170,6 +191,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release: OpenAPI 2.0 (Swagger) JSON to Markdown with grouping,
   filtering, sorting, and detail levels
 
+[0.5.1]: https://github.com/nrynss/vimanam/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/nrynss/vimanam/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/nrynss/vimanam/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/nrynss/vimanam/compare/v0.2.2...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vimanam"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vimanam"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["Narayan SS <nrynss@users.noreply.github.com>"]


### PR DESCRIPTION
Version bump to **0.5.1** + CHANGELOG, prerequisite for tagging `v0.5.1`.

## Contents
- `Cargo.toml` / `Cargo.lock`: `0.5.0` → `0.5.1`
- `CHANGELOG.md`: new `## [0.5.1]` section rolling up the merged work since 0.5.0:
  - **Fixed** — parse-layer cluster from #61: parameter `$ref` (#48), path-item `$ref` (#50), 3.1 `type` arrays (#51), missing `responses` (#56), duplicate params (#54), unknown-tag attribution (#60)
  - **Changed** — compressed-archive release artifacts (#24)

## After merge
Tagging `v0.5.1` triggers the release workflow:
1. `verify-version` — checks the tag matches `Cargo.toml` (now 0.5.1) ✓
2. GitHub release with notes extracted from the `## [0.5.1]` CHANGELOG section
3. **`cargo publish` to crates.io** (irreversible)
4. cross-platform archives + SHA256 checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)