### PR TITLE
Fix: Warn when --include-schemas or --include-examples is used without --detail full

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -144,7 +144,7 @@ pub fn build_config(cli: &Cli) -> DocConfig {
         cli.group_by.into()
     };
 
-    DocConfig {
+    let config = DocConfig {
         group_by,
         service_filter: cli.service_filter.clone(),
         path_filter: cli.path_filter.clone(),
@@ -163,5 +163,21 @@ pub fn build_config(cli: &Cli) -> DocConfig {
         include_toc: !cli.no_toc,
         sort_method: cli.sort.into(),
         max_tokens: cli.max_tokens,
+    };
+
+    // Warn if --include-schemas or --include-examples is set but detail is not Full
+    if config.include_schemas && config.detail_level != DetailLevel::Full {
+        eprintln!(
+            "vimanam: --include-schemas has no effect at --detail {:?}; use --detail full.",
+            cli.detail
+        );
     }
+    if config.include_examples && config.detail_level != DetailLevel::Full {
+        eprintln!(
+            "vimanam: --include-examples has no effect at --detail {:?}; use --detail full.",
+            cli.detail
+        );
+    }
+
+    config
 }


### PR DESCRIPTION
## Summary
- Fixes the silent no-op behavior of `--include-schemas` and `--include-examples` flags when used without `--detail full`
- Adds a warning message to stderr when these flags are set but the detail level is insufficient

## Changes
- Modified `src/config.rs` to emit warnings when `--include-schemas` or `--include-examples` is used with a detail level other than `full`
- Warning messages are printed to stderr via `eprintln!`

## Testing
- Verified warnings appear when flags are used with `--detail standard`, `--detail basic`, or `--detail summary`
- Verified no warnings appear when `--detail full` is used
- All existing tests pass (36 passed)

## Example
```bash
$ vimanam spec.json --detail standard --include-schemas
vimanam: --include-schemas has no effect at --detail Standard; use --detail full.
```

Fixes #59.
