### PR TITLE
Fix: Remove fabricated server URL and address cleanup issues

### DIFF
--- a/src/markdown/endpoint.rs
+++ b/src/markdown/endpoint.rs
@@ -21,7 +21,8 @@ pub(super) fn write_endpoint<W: Write>(
     let title = get_short_title(endpoint);
 
     if include_heading {
-        let anchor = clean_for_id(&title);
+        // Include method and path in anchor to avoid collisions
+        let anchor = clean_for_id(&format!("{} {}", endpoint.method, endpoint.path));
         writeln!(writer, "### {} {{#{}}}", title, anchor)?;
     } else {
         writeln!(writer, "**{}**", title)?;

--- a/src/markdown/views.rs
+++ b/src/markdown/views.rs
@@ -221,7 +221,8 @@ pub(super) fn generate_by_service<W: Write>(
                 for endpoint in sorted_ops {
                     // Extract a shorter title for the TOC entry
                     let op_title = get_short_title(endpoint);
-                    let op_anchor = clean_for_id(&op_title);
+                    // Use method + path for anchor to avoid collisions
+                    let op_anchor = clean_for_id(&format!("{} {}", endpoint.method, endpoint.path));
                     writeln!(writer, "  * [{}](#{op_anchor})", op_title)?;
                 }
             }
@@ -350,7 +351,8 @@ pub(super) fn generate_by_path<W: Write>(
             sort_endpoints(&mut sorted_ops, &config.sort_method);
             for endpoint in sorted_ops {
                 let op_title = get_short_title(endpoint);
-                let op_anchor = clean_for_id(&op_title);
+                // Use method + path for anchor to avoid collisions
+                let op_anchor = clean_for_id(&format!("{} {}", endpoint.method, endpoint.path));
                 writeln!(writer, "  * [{}](#{op_anchor})", op_title)?;
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -312,7 +312,7 @@ fn extract_endpoints(
                     // its content, otherwise the synthetic body is dropped.
                     let req_body = resolve_request_body_ref(spec_json, req_body)
                         .unwrap_or_else(|| req_body.clone());
-                    
+
                     // Iterate over all media types instead of just the first one
                     for (content_type, media_type) in &req_body.content {
                         let param_name = if req_body.content.len() > 1 {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -312,10 +312,17 @@ fn extract_endpoints(
                     // its content, otherwise the synthetic body is dropped.
                     let req_body = resolve_request_body_ref(spec_json, req_body)
                         .unwrap_or_else(|| req_body.clone());
-                    if let Some((_, media_type)) = req_body.content.first() {
+                    
+                    // Iterate over all media types instead of just the first one
+                    for (content_type, media_type) in &req_body.content {
+                        let param_name = if req_body.content.len() > 1 {
+                            format!("requestBody ({})", content_type)
+                        } else {
+                            "requestBody".to_string()
+                        };
                         parameters.push(Parameter {
                             reference: None,
-                            name: "requestBody".to_string(),
+                            name: param_name,
                             description: req_body.description.clone(),
                             parameter_in: "body".to_string(),
                             required: Some(req_body.required.unwrap_or(false)),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -147,11 +147,6 @@ pub fn extract_servers(spec: &OpenApiSpec) -> Vec<String> {
         }
     }
 
-    // Fallback to a default if empty
-    if servers.is_empty() {
-        servers.push("https://api.example.com".to_string());
-    }
-
     servers
 }
 


### PR DESCRIPTION
## Summary
- Fixes #52: Removes fabricated default server URL when spec declares none
- Fixes #56: Addresses two cleanup issues:
  - Request body now documents all media types (not just the first)
  - Anchor collisions are resolved by including method and path in endpoint anchors

## Changes

### 1. Fabricated Server URL (#52)
- **File:** `src/utils.rs`
- **Change:** Removed the fallback that pushed `"https://api.example.com"` when no servers were declared in the spec.
- **Impact:** The renderer already skips the "Server URLs" section when the list is empty, so no output change for specs with servers. For specs without servers, no fabricated URL is shown.

### 2. Request Body Media Types (#56)
- **File:** `src/parser.rs`
- **Change:** Iterate over all media types in `req_body.content` instead of just the first.
- **Impact:** When a request body offers multiple media types (e.g., JSON + XML), each is now documented as a separate parameter with the content type in parentheses (e.g., `requestBody (application/json)`).

### 3. Anchor Collisions (#56)
- **Files:** `src/markdown/endpoint.rs`, `src/markdown/views.rs`
- **Change:** Include HTTP method and path in endpoint anchors (e.g., `#get-pets` instead of `#listpets`).
- **Impact:** Ensures unique anchors even when multiple endpoints share the same title/summary.

## Testing
- All existing tests pass (36 passed)
- Manually verified:
  - No fabricated server URL for specs without servers
  - Multiple media types are documented for request bodies
  - Anchors are unique even for endpoints with identical titles

Fixes #52 and #56.
