### PR TITLE
feat: broaden YAML test coverage and introduce assert_matches! (#78, #76)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -204,3 +204,41 @@ fn detail_arg_name(detail: DetailLevelArg) -> &'static str {
         DetailLevelArg::Full => "full",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::assert_matches;
+
+    #[test]
+    fn test_detail_level_conversion() {
+        let cli = Cli {
+            input: PathBuf::from("spec.json"),
+            output: None,
+            method: false,
+            group_by: GroupByArg::Service,
+            flat: false,
+            service_filter: None,
+            path_filter: None,
+            method_filter: None,
+            exclude_deprecated: false,
+            required_only: false,
+            detail: DetailLevelArg::Summary,
+            include_schemas: false,
+            inline_schemas: false,
+            include_examples: false,
+            include_auth: false,
+            no_toc: false,
+            sort: SortArg::Alpha,
+            max_tokens: None,
+        };
+
+        let config = build_config(&cli);
+        assert_matches!(config.detail_level, DetailLevel::Summary);
+
+        let mut cli_basic = cli;
+        cli_basic.detail = DetailLevelArg::Basic;
+        let config_basic = build_config(&cli_basic);
+        assert_matches!(config_basic.detail_level, DetailLevel::Basic);
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -466,3 +466,23 @@ fn extract_examples(spec: &OpenApiSpec) -> IndexMap<String, Example> {
 
     examples
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::assert_matches;
+
+    #[test]
+    fn test_parse_non_existent_file() {
+        let res = parse_openapi("non_existent_file.json");
+        assert_matches!(res, Err(_));
+    }
+
+    #[test]
+    fn test_parse_invalid_format() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), "not json or yaml").unwrap();
+        let res = parse_openapi(temp.path());
+        assert_matches!(res, Err(_));
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,6 +12,8 @@ const OAS3_REF_BODY: &str = "tests/fixtures/ref_request_body_oas3.json";
 
 // YAML twin of petstore_oas3.json — must parse to identical documentation (#4).
 const OAS3_YAML: &str = "tests/fixtures/petstore_oas3.yaml";
+const OAS2_YAML: &str = "tests/fixtures/petstore_oas2.yaml";
+const OAS3_SCHEMA_REFS_YAML: &str = "tests/fixtures/schema_refs_oas3.yaml";
 
 // Parse-layer correctness cluster (issues #48, #50, #51, #54, #56, #60).
 const MULTI_TAG: &str = "tests/fixtures/multi_tag_oas3.json";
@@ -257,6 +259,42 @@ fn yaml_and_json_produce_identical_output() {
         render(OAS3),
         render(OAS3_YAML),
         "YAML and JSON inputs produced different output"
+    );
+}
+
+// The Swagger 2.0 (OAS2) YAML twin and its JSON counterpart must produce byte-identical documentation.
+#[test]
+fn yaml_and_json_produce_identical_output_oas2() {
+    let render = |spec: &str| {
+        vimanam()
+            .arg(spec)
+            .args(["--detail", "full", "--include-schemas", "--include-auth"])
+            .output()
+            .unwrap()
+            .stdout
+    };
+    assert_eq!(
+        render(OAS2),
+        render(OAS2_YAML),
+        "OAS2 YAML and JSON inputs produced different output"
+    );
+}
+
+// The $ref-heavy YAML twin of schema_refs_oas3.json must produce identical output.
+#[test]
+fn yaml_and_json_produce_identical_output_schema_refs() {
+    let render = |spec: &str| {
+        vimanam()
+            .arg(spec)
+            .args(["--detail", "full", "--include-schemas"])
+            .output()
+            .unwrap()
+            .stdout
+    };
+    assert_eq!(
+        render(OAS3_SCHEMA_REFS),
+        render(OAS3_SCHEMA_REFS_YAML),
+        "schema_refs YAML and JSON inputs produced different output"
     );
 }
 

--- a/tests/fixtures/petstore_oas2.yaml
+++ b/tests/fixtures/petstore_oas2.yaml
@@ -1,0 +1,36 @@
+swagger: "2.0"
+info:
+  title: Petstore Legacy API
+  version: "2.0.0"
+host: legacy.petstore.example.com
+basePath: /v2
+tags:
+  - name: Pets
+paths:
+  /pets:
+    post:
+      tags:
+        - Pets
+      summary: Create a pet
+      operationId: Pets_CreatePet
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: Pet to add
+          schema:
+            $ref: "#/definitions/Pet"
+      responses:
+        "200":
+          description: Created
+          schema:
+            $ref: "#/definitions/Pet"
+definitions:
+  Pet:
+    type: object
+securityDefinitions:
+  apiKey:
+    type: apiKey
+    name: api_key
+    in: header
+    description: API key auth

--- a/tests/fixtures/schema_refs_oas3.yaml
+++ b/tests/fixtures/schema_refs_oas3.yaml
@@ -1,0 +1,101 @@
+openapi: "3.0.0"
+info:
+  title: Schema Ref API
+  version: 1.0.0
+tags:
+  - name: Pets
+    description: Pet operations
+  - name: Nodes
+    description: Node operations
+paths:
+  /pets:
+    post:
+      tags:
+        - Pets
+      summary: Create pet
+      operationId: Pets_CreatePet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePetRequest"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+  /nodes/{nodeId}:
+    get:
+      tags:
+        - Nodes
+      summary: Get node
+      operationId: Nodes_GetNode
+      parameters:
+        - name: nodeId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Node payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Node"
+components:
+  schemas:
+    CreatePetRequest:
+      type: object
+      required:
+        - name
+        - category
+      properties:
+        name:
+          type: string
+          description: Pet name
+        age:
+          type: integer
+          format: int32
+        category:
+          $ref: "#/components/schemas/Category"
+        variant:
+          oneOf:
+            - type: string
+              description: Variant as string
+            - type: integer
+              description: Variant as integer
+    Category:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Category identifier
+        label:
+          type: string
+    Pet:
+      allOf:
+        - $ref: "#/components/schemas/CreatePetRequest"
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: string
+              description: Pet identifier
+            friends:
+              type: array
+              items:
+                $ref: "#/components/schemas/Pet"
+    Node:
+      type: object
+      properties:
+        id:
+          type: string
+        next:
+          $ref: "#/components/schemas/Node"


### PR DESCRIPTION
Resolves #78 and #76 as part of the v1.0.0 release milestone polish batch.

### Changes Included:
1. **OAS2 and $ref-heavy YAML test coverage (#78)**:
   - Added YAML twin fixtures for Swagger 2.0 (`petstore_oas2.yaml`) and $ref-heavy OpenAPI 3.0 (`schema_refs_oas3.yaml`).
   - Added integration tests to verify byte-identical output between JSON and YAML counterparts.
2. **`assert_matches!` adoption in unit tests (#76)**:
   - Added unit tests in `src/parser.rs` and `src/config.rs` using `std::assert_matches!` to assert on structural/variant outcomes.