### PR TITLE
ci: ignore non-code PR modifications in release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ permissions:
 # will be marked as a prerelease.
 on:
   pull_request:
+    paths:
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'dist-workspace.toml'
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'


### PR DESCRIPTION
## Summary

Fixes the issue where the full `release` workflow was executing on non-code updates (such as markdown modifications in pull requests).

### Root Cause
In `.github/workflows/release.yml`, the `pull_request:` trigger had no filters. Consequently, any pull request (e.g., editing `README.md` or other markdown assets) would execute the initial release dry-run/planning steps.

### Solution
We restrict the `pull_request` trigger in `release.yml` using `paths:` rules to match only relevant source code/dependency changes:
- `**.rs` (Rust source files)
- `Cargo.toml` / `Cargo.lock`
- `dist-workspace.toml`

With this setup, pull requests modifying documentation or metadata files will bypass the heavy `release.yml` workflow, while code changes still correctly plan the release pipeline.

Closes #83 (internal tracking)