### PR TITLE
fix: address code review findings (OAS2 schemes, --toc, warnings, stale docs)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Closes #
 - [ ] `cargo test` passes
 - [ ] Tests added/updated for behavior changes
 - [ ] `CHANGELOG.md` `[Unreleased]` updated (for user-facing changes)
-- [ ] MSRV (Rust 1.85) still builds, or the PR intentionally raises it
+- [ ] MSRV (Rust 1.96) still builds, or the PR intentionally raises it
 
 ## Notes for reviewers
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # See https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
 # Cargo.lock
 
+# Jujutsu VCS (jj also writes .jj/.gitignore itself; this covers fresh clones)
+.jj/
+
 # IDE / Editor files
 .idea/
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--toc` flag as the explicit opposite of `--no-toc`; when both are given, the
+  later one wins.
+- A "no effect" warning when `--required-only` is combined with `--detail basic`
+  or `--detail summary`, matching the existing `--include-schemas`/`--include-examples`
+  warnings.
+
+### Fixed
+
+- Swagger 2.0 `schemes` is now respected when building the server URL from
+  `host`/`basePath`; previously plain-HTTP specs were rendered with an assumed
+  `https://` prefix.
+
 ## [1.0.0] - 2026-06-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ cargo test optional_request_body     # run a single test by name substring
 cargo fmt && cargo clippy            # format / lint
 ```
 
-CI (`.github/workflows/ci.yml`) runs `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` on every push and pull request, plus an MSRV build on Rust 1.85. The release workflow (`.github/workflows/release.yml`) fires on a `v*` tag: it verifies the tag matches the `Cargo.toml` version, publishes to crates.io, and builds cross-platform binaries packaged as compressed archives with SHA256 checksums.
+CI (`.github/workflows/ci.yml`) runs `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` on every push and pull request, plus an MSRV build on Rust 1.96. The release workflow (`.github/workflows/release.yml`) fires on a `v*` tag: it verifies the tag matches the `Cargo.toml` version, publishes to crates.io, and builds cross-platform binaries packaged as compressed archives with SHA256 checksums.
 
 Real-world specs for manual testing may live at the repo root: `swagger.json` (small), `openapi.json` and `openapiv2.swagger.json` (~3 MB each). These and the root `*.md` sample outputs (`summary*.md`, `basicoutput.md`, `fulloutput.md`, etc.) are gitignored local artifacts — they won't exist in a fresh clone, and they're not docs to edit.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ process is light. Bug reports, feature ideas, and pull requests are all welcome.
 ## Getting started
 
 Vimanam is a standard Rust (edition 2021) CLI. You need a Rust toolchain; the
-minimum supported version (MSRV) is **1.85**.
+minimum supported version (MSRV) is **1.96**.
 
 ```bash
 git clone https://github.com/noemaforge/vimanam.git
@@ -25,7 +25,7 @@ cargo clippy --all-targets -- -D warnings  # lint (warnings are errors)
 cargo test                                 # integration tests (tests/cli.rs)
 ```
 
-CI also builds against the MSRV (Rust 1.85) on every pull request, so avoid
+CI also builds against the MSRV (Rust 1.96) on every pull request, so avoid
 language or dependency features newer than that unless you intend to raise the
 MSRV deliberately (and call it out in the PR).
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,11 @@ pub struct Cli {
     #[arg(long)]
     pub include_auth: bool,
 
+    /// Include the table of contents (the default; when both are given,
+    /// the later of --toc/--no-toc wins)
+    #[arg(long, overrides_with = "no_toc")]
+    pub toc: bool,
+
     /// Skip table of contents
     #[arg(long)]
     pub no_toc: bool,
@@ -166,7 +171,9 @@ pub fn build_config(cli: &Cli) -> DocConfig {
         inline_schemas: cli.inline_schemas,
         include_examples: cli.include_examples,
         include_auth: cli.include_auth,
-        include_toc: !cli.no_toc,
+        // `--toc`/`--no-toc` override each other (last one wins), so at most
+        // one of the pair is set; the TOC stays on unless --no-toc survives.
+        include_toc: cli.toc || !cli.no_toc,
         sort_method: cli.sort.into(),
         max_tokens: cli.max_tokens,
     };
@@ -189,6 +196,18 @@ pub fn build_config(cli: &Cli) -> DocConfig {
     // without --include-schemas.
     if config.inline_schemas && !config.include_schemas {
         eprintln!("vimanam: --inline-schemas has no effect without --include-schemas.");
+    }
+    // --required-only only filters the parameters table, which is rendered at
+    // --detail standard and full.
+    if config.required_only
+        && matches!(
+            config.detail_level,
+            DetailLevel::Basic | DetailLevel::Summary
+        )
+    {
+        eprintln!(
+            "vimanam: --required-only has no effect at --detail {detail_name}; use --detail standard or full."
+        );
     }
 
     config
@@ -228,6 +247,7 @@ mod tests {
             inline_schemas: false,
             include_examples: false,
             include_auth: false,
+            toc: false,
             no_toc: false,
             sort: SortArg::Alpha,
             max_tokens: None,

--- a/src/markdown/views.rs
+++ b/src/markdown/views.rs
@@ -169,12 +169,10 @@ pub(super) fn generate_summary<W: Write>(
             for endpoint in sorted_ops {
                 let op_name = if let Some(operation_id) = &endpoint.operation_id {
                     // Clean up the operation ID by removing the service name prefix if present
-                    if operation_id.starts_with(&format!("{}_", service.name)) {
-                        // Remove the "ServiceName_" prefix
-                        operation_id.replacen(&format!("{}_", service.name), "", 1)
-                    } else {
-                        operation_id.clone()
-                    }
+                    operation_id
+                        .strip_prefix(&format!("{}_", service.name))
+                        .unwrap_or(operation_id)
+                        .to_string()
                 } else {
                     // Fallback if no operation ID
                     format!("{} {}", endpoint.method, endpoint.path)

--- a/src/models.rs
+++ b/src/models.rs
@@ -164,6 +164,9 @@ pub struct Parameter {
     pub extensions: HashMap<String, serde_json::Value>,
 }
 
+// `Default` is for constructing schemas in code (tests build partial schemas
+// via `..Schema::default()`); serde does not consult it during deserialization
+// — missing fields fall back to `Option`/empty-map defaults on their own.
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Schema {
     #[serde(rename = "title", skip_serializing_if = "Option::is_none")]
@@ -208,6 +211,10 @@ pub struct Schema {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Response {
+    // A response may be given as a `$ref` into `components/responses`;
+    // `resolve_response_ref` resolves it during parsing.
+    #[serde(rename = "$ref", skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
     pub description: Option<String>,
     pub schema: Option<Schema>,
     #[serde(rename = "content", skip_serializing_if = "Option::is_none")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -67,18 +67,18 @@ pub fn resolve_parameter_ref(
     }
 }
 
-/// Resolves a response reference to a concrete response
+/// Resolves a response that may be a `$ref` into `components/responses`,
+/// returning the response unchanged when it carries no reference. Returns
+/// `None` when a `$ref` is present but cannot be resolved.
 pub fn resolve_response_ref(
     spec_json: &serde_json::Value,
     response: &Response,
 ) -> Option<Response> {
-    if let Some(extensions) = response.extensions.get("$ref")
-        && let Some(reference) = extensions.as_str()
-        && let Some(resolved) = resolve_ref(spec_json, reference)
-    {
-        return serde_json::from_value(resolved).ok();
+    match &response.reference {
+        None => Some(response.clone()),
+        Some(reference) => resolve_ref(spec_json, reference)
+            .and_then(|resolved| serde_json::from_value(resolved).ok()),
     }
-    Some(response.clone())
 }
 
 /// Resolves a request body that may itself be a `$ref` into
@@ -130,7 +130,16 @@ pub fn extract_servers(spec: &OpenApiSpec) -> Vec<String> {
         let mut base_url = if host_str.starts_with("http") {
             host_str.to_string()
         } else {
-            format!("https://{}", host_str)
+            // Swagger 2.0 lists its transfer protocols in `schemes`; use the
+            // first entry and assume https only when the spec doesn't say.
+            let scheme = spec
+                .extensions
+                .get("schemes")
+                .and_then(|schemes| schemes.as_array())
+                .and_then(|schemes| schemes.first())
+                .and_then(|scheme| scheme.as_str())
+                .unwrap_or("https");
+            format!("{}://{}", scheme, host_str)
         };
 
         // Add basePath if present

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,6 +17,7 @@ const OAS3_SCHEMA_REFS_YAML: &str = "tests/fixtures/schema_refs_oas3.yaml";
 
 // Parse-layer correctness cluster (issues #48, #50, #51, #54, #56, #60).
 const MULTI_TAG: &str = "tests/fixtures/multi_tag_oas3.json";
+const OAS2_HTTP_SCHEME: &str = "tests/fixtures/http_scheme_oas2.json";
 const REF_PARAMETER: &str = "tests/fixtures/ref_parameter.json";
 const REF_PATH_ITEM: &str = "tests/fixtures/ref_path_item.json";
 const TYPE_ARRAY: &str = "tests/fixtures/type_array_nullable.json";
@@ -210,6 +211,20 @@ fn oas2_spec_is_supported() {
         .stdout(predicate::str::contains(
             "| 200 | application/json | Created |",
         ));
+}
+
+// The OAS2 `schemes` field names the transfer protocol; a plain-HTTP spec must
+// not be rendered with an assumed `https://` prefix. (Specs without `schemes`
+// still default to https — covered by `oas2_spec_is_supported` above.)
+#[test]
+fn oas2_http_scheme_is_respected() {
+    vimanam()
+        .arg(OAS2_HTTP_SCHEME)
+        .arg("--include-auth")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("http://internal.example.com/v1"))
+        .stdout(predicate::str::contains("https://internal.example.com").not());
 }
 
 #[test]
@@ -544,6 +559,57 @@ fn inline_schemas_without_include_schemas_warns() {
         .stderr(predicate::str::contains(
             "--inline-schemas has no effect without --include-schemas.",
         ));
+}
+
+// `--required-only` only filters the parameters table, which basic/summary
+// detail never renders — so it warns there like the other no-effect flags.
+#[test]
+fn required_only_at_basic_detail_warns() {
+    vimanam()
+        .arg(OAS3)
+        .args(["--detail", "basic", "--required-only"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "--required-only has no effect at --detail basic; use --detail standard or full.",
+        ));
+}
+
+// At `--detail standard` the flag takes effect, so no warning is emitted.
+#[test]
+fn required_only_at_standard_detail_emits_no_warning() {
+    vimanam()
+        .arg(OAS3)
+        .args(["--detail", "standard", "--required-only"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("no effect").not());
+}
+
+// `--toc` is the explicit opposite of `--no-toc`; the TOC is on by default, and
+// when both flags are given the later one wins.
+#[test]
+fn toc_flag_is_accepted_and_last_one_wins() {
+    vimanam()
+        .arg(OAS3)
+        .args(["--detail", "basic", "--toc"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("## Services"));
+
+    vimanam()
+        .arg(OAS3)
+        .args(["--detail", "basic", "--no-toc", "--toc"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("## Services"));
+
+    vimanam()
+        .arg(OAS3)
+        .args(["--detail", "basic", "--toc", "--no-toc"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("## Services").not());
 }
 
 // #70 follow-up: an operation carrying multiple tags is rendered under each

--- a/tests/fixtures/http_scheme_oas2.json
+++ b/tests/fixtures/http_scheme_oas2.json
@@ -1,0 +1,21 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Plain HTTP API",
+    "version": "1.0.0"
+  },
+  "host": "internal.example.com",
+  "basePath": "/v1",
+  "schemes": ["http"],
+  "paths": {
+    "/status": {
+      "get": {
+        "summary": "Service status",
+        "operationId": "GetStatus",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the actionable findings from a full-codebase review. One real output bug, two CLI polish items, two model-clarity cleanups, and a sweep of stale docs.

**Bug fix — OAS2 server URLs assumed HTTPS.** `extract_servers` never read the Swagger 2.0 `schemes` field, so a plain-HTTP spec (`"schemes": ["http"]`) rendered `https://host/basePath`. It now uses the first `schemes` entry and only defaults to `https` when the spec doesn't say. New fixture `tests/fixtures/http_scheme_oas2.json` + test; the existing no-`schemes` fixture still covers the https default.

**CLI polish:**
- `--required-only` now warns when combined with `--detail basic`/`summary` (where parameter tables never render), matching the existing `--include-schemas`/`--include-examples`/`--inline-schemas` warnings.
- Added `--toc` as the explicit opposite of `--no-toc` via clap `overrides_with` — TOC stays on by default, and when both flags are given the later one wins. Backward compatible.

**Cleanups:**
- `Response` gets a dedicated `#[serde(rename = "$ref")] reference` field instead of `resolve_response_ref` fishing the ref out of the flattened `extensions` map — consistent with `Parameter`, `RequestBody`, and `PathItem`. Behavior at the only call site is unchanged.
- Summary view uses `strip_prefix` instead of a `starts_with` + `replacen` pair (drops a redundant `format!` allocation).
- Comment on `Schema` clarifying its `Default` derive is for in-code construction, not a serde deserialization fallback.

**Stale docs:** MSRV references still said 1.85 (actual: 1.96 since 1.0.0) in CLAUDE.md, CONTRIBUTING.md, and the PR template. Also added `.jj/` to `.gitignore` for fresh clones (jj self-ignores in colocated repos, but this covers checkouts before `jj git init --colocate`).

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (85 tests: 30 unit + 55 integration, 4 new)
- [x] Tests added/updated for behavior changes
- [x] `CHANGELOG.md` `[Unreleased]` updated (for user-facing changes)
- [x] MSRV (Rust 1.96) still builds, or the PR intentionally raises it

## Notes for reviewers

- The `schemes` fix uses the **first** array entry per spec order. An alternative is preferring `https` when present anywhere in the list; first-entry felt closer to author intent and is deterministic.
- Reviewed-but-not-changed: multi-content-type request bodies still render one `requestBody (<type>)` row per content type (working as designed), and response `$ref` resolution behavior is identical — only the model shape changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)